### PR TITLE
Add Magento_Tax to module.xml sequence.

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -21,6 +21,7 @@
             <module name="Magento_Checkout"/>
             <module name="Magento_Customer"/>
             <module name="Magento_Sales"/>
+            <module name="Magento_Tax"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Magento 2.0.4 EE cli install with module already loaded in composer.json fails with error:

```
[Progress: 102 / 459]
Module 'ClassyLlama_AvaTax':
Installing schema.. Upgrading schema.. 
                                                                                                                                       
  [Zend_Db_Statement_Exception]                                                                                                         
  SQLSTATE[42S02]: Base table or view not found: 1146 Table '***.tax_class' doesn't exist, query was: DESCRIBE `tax_class`  
                                                                                                       
  [PDOException]                                                                                       
  SQLSTATE[42S02]: Base table or view not found: 1146 Table '***.tax_class' doesn't exist  
```
                                                                                                       
