### PR TITLE
Add Validate Address endpoint with restricted integration permissions.

### DIFF
--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -22,4 +22,10 @@
             <resource ref="self" />
         </resources>
     </route>
+    <route url="/V1/carts/validate-address" method="POST">
+        <service class="ClassyLlama\AvaTax\Api\ValidAddressManagementInterface" method="saveValidAddress"/>
+        <resources>
+            <resource ref="Magento_Cart::manage" />
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
This adds an additional API endpoint that calls the same service for address validation but allows API integration clients with restricted (`Magento_Cart::manage`) permissions to validate addresses.