### PR TITLE
Region lookup fix

### DIFF
--- a/Framework/Interaction/Address.php
+++ b/Framework/Interaction/Address.php
@@ -404,7 +404,7 @@ class Address
         }
         // Not using line 4, as it returns a concatenation of city, state, and zip (e.g., BAINBRIDGE IS WA 98110-2450)
 
-        $region = $this->getRegionByCode($address->getRegion());
+        $region = $this->getRegionByCodeAndCountry($address->getRegion(), $address->getCountry());
         if (is_null($region)) {
             return null;
         }
@@ -456,7 +456,7 @@ class Address
             QuoteAddressInterface::KEY_CITY => $address->getCity(),
         ]);
 
-        $region = $this->getRegionByCode($address->getRegion());
+        $region = $this->getRegionByCodeAndCountry($address->getRegion(), $address->getCountry());
         if (!is_null($region)) {
             $data[QuoteAddressInterface::KEY_REGION_ID] = $region->getId();
             $data[QuoteAddressInterface::KEY_REGION] = $region;
@@ -496,12 +496,12 @@ class Address
      * @param $regionCode
      * @return \Magento\Framework\DataObject|null
      */
-    protected function getRegionByCode($regionCode)
+    protected function getRegionByCodeAndCountry($regionCode, $countryCode)
     {
 
         /* @var $region \Magento\Framework\DataObject */
         foreach ($this->regionCollection as $region) {
-            if ($region->getCode() == $regionCode) {
+            if ($region->getCode() == $regionCode && $region->getCountryId() == $countryCode) {
                 return $region;
             }
         }

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -22,4 +22,10 @@
             <resource ref="self" />
         </resources>
     </route>
+    <route url="/V1/carts/validate-address" method="POST">
+        <service class="ClassyLlama\AvaTax\Api\ValidAddressManagementInterface" method="saveValidAddress"/>
+        <resources>
+            <resource ref="Magento_Cart::manage" />
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
Fix to address region lookup when validating addresses. Before this fix, a region code of ```PA``` could potentially pick up ```Pennsylvania``` or ```Pará``` depending on what was first in the result set. This PR forces the validation to also consider the country code.