### PR TITLE
Missing Semicolon in checkout-validation-handler.js

### DIFF
--- a/view/frontend/web/js/view/checkout-validation-handler.js
+++ b/view/frontend/web/js/view/checkout-validation-handler.js
@@ -48,7 +48,7 @@ define(
                     }
                     addressModel.originalAddress(response.extension_attributes.original_address);
                     if (typeof response.extension_attributes.error_message !== 'undefined') {
-                        addressModel.error(response.extension_attributes.error_message)
+                        addressModel.error(response.extension_attributes.error_message);
                     }
                     addressValidationForm.fillValidateForm(this.options.validateAddressContainerSelector);
                     if (!addressModel.isDifferent() && addressModel.error() == null) {


### PR DESCRIPTION
Typically not an issue, but was giving me hell when Magento was minifying and merging JS files.