### PR TITLE
#421_42 - Fix to allow free items on invoices

### DIFF
--- a/Framework/Interaction/Line.php
+++ b/Framework/Interaction/Line.php
@@ -163,7 +163,7 @@ class Line
         // from taxable amount
         $amount = $item->getBaseRowTotal() - $item->getBaseDiscountAmount();
 
-        if ($item->getQty() == 0 || $amount == 0) {
+        if ($item->getQty() == 0) {
             return false;
         }
         $product = $item->getOrderItem()->getProduct();
@@ -209,7 +209,7 @@ class Line
         // Credit memo amounts need to be sent to AvaTax as negative numbers
         $amount *= -1;
 
-        if ($item->getQty() == 0 || $amount == 0) {
+        if ($item->getQty() == 0) {
             return false;
         }
 


### PR DESCRIPTION
Fix to allow free items on invoices with $0 totals and no shipping to be submitted during queue processing.

- Fixes Error: Lines is expected to be between 1 and 15000
  When free items were on an order that did not have shipping there
  were no lines attached to the invoices submitted. That sent an empty
  array which caused the error. Lines is a required parameter of the
  GetTaxRequest method, but the amount of a line is allowed to be 0.
- This change allows for the inclusion of $0 line items on invoices
  and credit memos where they were previously excluded.

This should address Issue #46 

API References for the GetTaxRequest: https://developer.avalara.com/avatax/api-reference/tax/soap/