### PR TITLE
Feature/421 48 add support for split db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     * Refactor code to store AvaTax data in new tables instead of attaching to entities
 * Add support for [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html) [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54)
     * Refactor code to create AvaTax tables in the 'sales' database when running in split database mode
-    * Reference issue [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54) for additonal notes
+    * Reference issue [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54) for additional notes and details
 
 ### 0.3.4 (2017-02-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
-### 1.0.0 (2017-03-17)
+### 1.0.0 (2017-04-14)
 
+* Add support for [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html) [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54)
+    * Refactor code to create AvaTax tables in the 'sales' database when running in split database mode
+    * Reference issue [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54) for additional notes and details
+
+### 0.4.0 (2017-03-14)
+    
 * Add code to create new database tables dedicated to storing AvaTax data [#47](https://github.com/classyllama/ClassyLlama_AvaTax/issues/47) and [#40](https://github.com/classyllama/ClassyLlama_AvaTax/issues/40)
     * Add code to migrate existing data from AvaTax columns on sales_invoice and sales_creditmemo tables to new tables
     * Add code to remove existing AvaTax columns after migrating data
     * Refactor code to store AvaTax data in new tables instead of attaching to entities
-* Add support for [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html) [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54)
-    * Refactor code to create AvaTax tables in the 'sales' database when running in split database mode
-    * Reference issue [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54) for additional notes and details
 
 ### 0.3.5 (2017-03-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-### 0.4.0 (2017-03-14)
+### 1.0.0 (2017-03-17)
 
-* Add code to create new database tables dedicated to storing AvaTax data
-* Add code to migrate existing data from AvaTax columns on sales_invoice and sales_creditmemo tables to new tables
-* Refactor code to store AvaTax data in new tables instead of attaching to entities
+* Add code to create new database tables dedicated to storing AvaTax data [#47](https://github.com/classyllama/ClassyLlama_AvaTax/issues/47) and [#40](https://github.com/classyllama/ClassyLlama_AvaTax/issues/40)
+    * Add code to migrate existing data from AvaTax columns on sales_invoice and sales_creditmemo tables to new tables
+    * Add code to remove existing AvaTax columns after migrating data
+    * Refactor code to store AvaTax data in new tables instead of attaching to entities
+* Add support for [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html) [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54)
+    * Refactor code to create AvaTax tables in the 'sales' database when running in split database mode
+    * Reference issue [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54) for additonal notes
 
 ### 0.3.4 (2017-02-04)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This extension contains integration tests to verify the extension's functionalit
 
 As of version 0.3.0 of this extension, this extension supported Magento 2.1.x (Community and Enterprise). Suppport for Magento 2.0.x was dropped as of version 0.3.0. See [this page](https://github.com/classyllama/ClassyLlama_AvaTax/releases) for a list of all releases.
 
-As of version 1.0.0 of this extension, this extension supports [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html).
+As of version 1.0.0 of this extension, this extension supports [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html).  Reference issue [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54) for additional notes and details.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This extension contains integration tests to verify the extension's functionalit
 
 As of version 0.3.0 of this extension, this extension supported Magento 2.1.x (Community and Enterprise). Suppport for Magento 2.0.x was dropped as of version 0.3.0. See [this page](https://github.com/classyllama/ClassyLlama_AvaTax/releases) for a list of all releases.
 
+As of version 1.0.0 of this extension, this extension supports [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html).
+
 # License
 
 This project is licensed under the Open Software License 3.0 (OSL-3.0). See included LICENSE file for full text of OSL-3.0

--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -27,6 +27,13 @@ use Magento\Framework\DB\Ddl\Table;
 class InstallSchema implements InstallSchemaInterface
 {
     /**
+     * Define connection name to connect to 'sales' database on split database install; falls back to default for a
+     * conventional install
+     * @var string
+     */
+    private static $connectionName = 'sales';
+
+    /**
      * {@inheritdoc}
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
@@ -38,7 +45,7 @@ class InstallSchema implements InstallSchemaInterface
         /**
          * Create table 'avatax_log'
          */
-        $table = $installer->getConnection()
+        $table = $installer->getConnection(self::$connectionName)
             ->newTable(
                 $installer->getTable('avatax_log')
             )
@@ -134,12 +141,12 @@ class InstallSchema implements InstallSchemaInterface
                 ['type' => \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_INDEX]
             )
             ->setComment('AvaTax Log Table');
-        $installer->getConnection()->createTable($table);
+        $installer->getConnection(self::$connectionName)->createTable($table);
 
         /**
          * Create table 'avatax_queue'
          */
-        $table = $installer->getConnection()
+        $table = $installer->getConnection(self::$connectionName)
             ->newTable(
                 $installer->getTable('avatax_queue')
             )
@@ -268,12 +275,12 @@ class InstallSchema implements InstallSchemaInterface
                 ]
             )
             ->setComment('AvaTax Queue Table');
-        $installer->getConnection()->createTable($table);
+        $installer->getConnection(self::$connectionName)->createTable($table);
 
         /**
          * Create table 'avatax_sales_invoice'
          */
-        $table = $setup->getConnection()
+        $table = $setup->getConnection(self::$connectionName)
             ->newTable(
                 $setup->getTable('avatax_sales_invoice')
             )
@@ -348,12 +355,12 @@ class InstallSchema implements InstallSchemaInterface
                 Table::ACTION_CASCADE
             )
             ->setComment('AvaTax Sales Invoice Table');
-        $setup->getConnection()->createTable($table);
+        $setup->getConnection(self::$connectionName)->createTable($table);
 
         /**
          * Create table 'avatax_sales_creditmemo'
          */
-        $table = $setup->getConnection()
+        $table = $setup->getConnection(self::$connectionName)
             ->newTable(
                 $setup->getTable('avatax_sales_creditmemo')
             )
@@ -428,7 +435,7 @@ class InstallSchema implements InstallSchemaInterface
                 Table::ACTION_CASCADE
             )
             ->setComment('AvaTax Sales Credit Memo Table');
-        $setup->getConnection()->createTable($table);
+        $setup->getConnection(self::$connectionName)->createTable($table);
 
         $installer->endSetup();
     }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -13,6 +13,13 @@ use Magento\Framework\Setup\ModuleContextInterface;
 class UpgradeData implements UpgradeDataInterface
 {
     /**
+     * Define connection name to connect to 'sales' database on split database install; falls back to default for a
+     * conventional install
+     * @var string
+     */
+    private static $connectionName = 'sales';
+    
+    /**
      * Upgrade scripts
      *
      * @param ModuleDataSetupInterface $setup
@@ -20,15 +27,17 @@ class UpgradeData implements UpgradeDataInterface
      */
     public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context) {
         $setup->startSetup();
-        if (version_compare($context->getVersion(), '0.4.0', '<' )) {
+        if (version_compare($context->getVersion(), '1.0.0', '<' )) {
 
             // Only copy data and drop columns from "sales_invoice" if the columns exist
             if (
-                $setup->getConnection()->tableColumnExists('sales_invoice', 'avatax_is_unbalanced')
-                && $setup->getConnection()->tableColumnExists('sales_invoice', 'base_avatax_tax_amount')
+                $setup->getConnection(self::$connectionName)
+                    ->tableColumnExists('sales_invoice', 'avatax_is_unbalanced')
+                && $setup->getConnection(self::$connectionName)
+                    ->tableColumnExists('sales_invoice', 'base_avatax_tax_amount')
             ) {
                 // Copy any existing AvaTax data from core Invoice table into new AvaTax Invoice table
-                $select = $setup->getConnection()->select()
+                $select = $setup->getConnection(self::$connectionName)->select()
                     ->from(
                         $setup->getTable('sales_invoice'),
                         [
@@ -37,7 +46,7 @@ class UpgradeData implements UpgradeDataInterface
                             'base_avatax_tax_amount'
                         ])
                     ->where('base_avatax_tax_amount IS NOT NULL OR avatax_is_unbalanced IS NOT NULL');
-                $select = $setup->getConnection()->insertFromSelect(
+                $select = $setup->getConnection(self::$connectionName)->insertFromSelect(
                     $select,
                     $setup->getTable('avatax_sales_invoice'),
                     [
@@ -46,17 +55,17 @@ class UpgradeData implements UpgradeDataInterface
                         'base_avatax_tax_amount'
                     ]
                 );
-                $setup->getConnection()->query($select);
+                $setup->getConnection(self::$connectionName)->query($select);
 
                 // Drop "avatax_is_unbalanced" column from "sales_invoice" table
-                $setup->getConnection()
+                $setup->getConnection(self::$connectionName)
                     ->dropColumn(
                         $setup->getTable('sales_invoice'),
                         'avatax_is_unbalanced'
                     );
 
                 // Drop "base_avatax_tax_amount" column from "sales_invoice" table
-                $setup->getConnection()
+                $setup->getConnection(self::$connectionName)
                     ->dropColumn(
                         $setup->getTable('sales_invoice'),
                         'base_avatax_tax_amount'
@@ -65,11 +74,13 @@ class UpgradeData implements UpgradeDataInterface
 
             // Only copy data and drop columns from "sales_creditmemo" if the columns exist
             if (
-                $setup->getConnection()->tableColumnExists('sales_creditmemo', 'avatax_is_unbalanced')
-                && $setup->getConnection()->tableColumnExists('sales_creditmemo', 'base_avatax_tax_amount')
+                $setup->getConnection(self::$connectionName)
+                    ->tableColumnExists('sales_creditmemo', 'avatax_is_unbalanced')
+                && $setup->getConnection(self::$connectionName)
+                    ->tableColumnExists('sales_creditmemo', 'base_avatax_tax_amount')
             ) {
                 // Copy any existing AvaTax data from core Credit Memo table into new AvaTax Credit Memo table
-                $select = $setup->getConnection()->select()
+                $select = $setup->getConnection(self::$connectionName)->select()
                     ->from(
                         $setup->getTable('sales_creditmemo'),
                         [
@@ -78,7 +89,7 @@ class UpgradeData implements UpgradeDataInterface
                             'base_avatax_tax_amount'
                         ])
                     ->where('base_avatax_tax_amount IS NOT NULL OR avatax_is_unbalanced IS NOT NULL');
-                $select = $setup->getConnection()->insertFromSelect(
+                $select = $setup->getConnection(self::$connectionName)->insertFromSelect(
                     $select,
                     $setup->getTable('avatax_sales_creditmemo'),
                     [
@@ -87,17 +98,17 @@ class UpgradeData implements UpgradeDataInterface
                         'base_avatax_tax_amount'
                     ]
                 );
-                $setup->getConnection()->query($select);
+                $setup->getConnection(self::$connectionName)->query($select);
 
                 // Drop "avatax_is_unbalanced" column from "sales_creditmemo" table
-                $setup->getConnection()
+                $setup->getConnection(self::$connectionName)
                     ->dropColumn(
                         $setup->getTable('sales_creditmemo'),
                         'avatax_is_unbalanced'
                     );
 
                 // Drop "base_avatax_tax_amount" column from "sales_creditmemo" table
-                $setup->getConnection()
+                $setup->getConnection(self::$connectionName)
                     ->dropColumn(
                         $setup->getTable('sales_creditmemo'),
                         'base_avatax_tax_amount'

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -42,7 +42,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             /**
              * Add "avatax_code" column to tax_class table
              */
-            $setup->getConnection(self::$connectionName)
+            $setup->getConnection()
                 ->addColumn(
                     $setup->getTable('tax_class'),
                     'avatax_code',

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -26,6 +26,13 @@ use Magento\Framework\DB\Ddl\Table;
 class UpgradeSchema implements UpgradeSchemaInterface
 {
     /**
+     * Define connection name to connect to 'sales' database on split database install; falls back to default for a
+     * conventional install
+     * @var string
+     */
+    private static $connectionName = 'sales';
+
+    /**
      * {@inheritdoc}
      */
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
@@ -35,7 +42,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             /**
              * Add "avatax_code" column to tax_class table
              */
-            $setup->getConnection()
+            $setup->getConnection(self::$connectionName)
                 ->addColumn(
                     $setup->getTable('tax_class'),
                     'avatax_code',
@@ -49,7 +56,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 );
         }
 
-        if (version_compare($context->getVersion(), '0.4.0', '<')) {
+        if (version_compare($context->getVersion(), '1.0.0', '<')) {
             /** As a part of the upgrade process for this revision, data is migrated from the sales_invoice and
              * sales_creditmemo tables into the newly created tables above.  After the data migration, the previously
              * mentioned tables are altered to drop the now-unused columns in each (base_avatax_tax_amount and
@@ -59,7 +66,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             /**
              * Create table 'avatax_sales_invoice'
              */
-            $table = $setup->getConnection()
+            $table = $setup->getConnection(self::$connectionName)
                 ->newTable(
                     $setup->getTable('avatax_sales_invoice')
                 )
@@ -134,12 +141,12 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     Table::ACTION_CASCADE
                 )
                 ->setComment('AvaTax Sales Invoice Table');
-            $setup->getConnection()->createTable($table);
+            $setup->getConnection(self::$connectionName)->createTable($table);
 
             /**
              * Create table 'avatax_sales_creditmemo'
              */
-            $table = $setup->getConnection()
+            $table = $setup->getConnection(self::$connectionName)
                 ->newTable(
                     $setup->getTable('avatax_sales_creditmemo')
                 )
@@ -214,7 +221,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     Table::ACTION_CASCADE
                 )
                 ->setComment('AvaTax Sales Credit Memo Table');
-            $setup->getConnection()->createTable($table);
+            $setup->getConnection(self::$connectionName)->createTable($table);
         }
         $setup->endSetup();
     }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -95,4 +95,30 @@
             </argument>
         </arguments>
     </type>
+    <!--
+    /**
+     * The following code will rewrite the connection name to connect to 'sales' database on split database install;
+     * falls back to default for a conventional install
+     */
+     -->
+    <type name="ClassyLlama\AvaTax\Model\ResourceModel\CreditMemo">
+        <arguments>
+            <argument name="connectionName" xsi:type="string">sales</argument>
+        </arguments>
+    </type>
+    <type name="ClassyLlama\AvaTax\Model\ResourceModel\Invoice">
+        <arguments>
+            <argument name="connectionName" xsi:type="string">sales</argument>
+        </arguments>
+    </type>
+    <type name="ClassyLlama\AvaTax\Model\ResourceModel\Log">
+        <arguments>
+            <argument name="connectionName" xsi:type="string">sales</argument>
+        </arguments>
+    </type>
+    <type name="ClassyLlama\AvaTax\Model\ResourceModel\Queue">
+        <arguments>
+            <argument name="connectionName" xsi:type="string">sales</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <!-- The setup_version attribute is unrelated to the module version stored in composer.json -->
-    <module name="ClassyLlama_AvaTax" setup_version="0.4.0">
+    <module name="ClassyLlama_AvaTax" setup_version="1.0.0">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Customer"/>


### PR DESCRIPTION
* Add support for [Magento Enterprise's split database mode](http://devdocs.magento.com/guides/v2.1/config-guide/multi-master/multi-master.html) [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54)
    * Refactor code to create AvaTax tables in the 'sales' database when running in split database mode
    * Reference issue [#54](https://github.com/classyllama/ClassyLlama_AvaTax/issues/54) for additional notes and details