### PR TITLE
Feature/avs 421 74 expand customer attributes for customer code

### DIFF
--- a/Model/Config/Source/CustomerCode.php
+++ b/Model/Config/Source/CustomerCode.php
@@ -53,14 +53,14 @@ class CustomerCode implements \Magento\Framework\Option\ArrayInterface
 
         // Retrieve all customer attributes
         $customerAttributes = $this->customer->getAttributes();
-        foreach($customerAttributes as $attribute){
+        foreach ($customerAttributes as $attribute){
             $label = $attribute->getDefaultFrontendLabel();
             if (!is_null($label) && $attribute->getIsUserDefined()) {
                 // Only add custom attribute codes that have a frontend label value defined
-                $attributesArray[$attribute->getAttributeCode()] = array(
+                $attributesArray[$attribute->getAttributeCode()] = [
                     'value' => $attribute->getAttributeCode(),
                     'label' => __($label)
-                );
+                ];
             }
         }
 

--- a/Model/Config/Source/CustomerCode.php
+++ b/Model/Config/Source/CustomerCode.php
@@ -16,18 +16,57 @@
 namespace ClassyLlama\AvaTax\Model\Config\Source;
 
 use ClassyLlama\AvaTax\Helper\Config;
+use Magento\Customer\Model\Customer;
 
 class CustomerCode implements \Magento\Framework\Option\ArrayInterface
 {
+    /**
+     * @var Customer
+     */
+    protected $customer;
+
+    /**
+     * CustomerCode constructor.
+     *
+     * @param Customer $customer
+     */
+    public function __construct(Customer $customer)
+    {
+        $this->customer = $customer;
+    }
+
     /**
      * @return array
      */
     public function toOptionArray()
     {
-        return [
-            ['value' => Config::CUSTOMER_FORMAT_OPTION_ID, 'label' => __('ID')],
-            ['value' => Config::CUSTOMER_FORMAT_OPTION_EMAIL, 'label' => __('Email')],
-            ['value' => Config::CUSTOMER_FORMAT_OPTION_NAME_ID, 'label' => __('Name (ID)')],
+        // Define attributes array with default config values to include
+        $attributesArray[Config::CUSTOMER_FORMAT_OPTION_ID] = [
+            'value' => Config::CUSTOMER_FORMAT_OPTION_ID, 'label' => __('ID')
         ];
+        $attributesArray[Config::CUSTOMER_FORMAT_OPTION_EMAIL] = [
+            'value' => Config::CUSTOMER_FORMAT_OPTION_EMAIL, 'label' => __('Email')
+        ];
+        $attributesArray[Config::CUSTOMER_FORMAT_OPTION_NAME_ID] = [
+            'value' => Config::CUSTOMER_FORMAT_OPTION_NAME_ID, 'label' => __('Name (ID)')
+        ];
+
+        // Retrieve all customer attributes
+        $customerAttributes = $this->customer->getAttributes();
+        foreach($customerAttributes as $attribute){
+            $label = $attribute->getDefaultFrontendLabel();
+            if (!is_null($label) && $attribute->getIsUserDefined()) {
+                // Only add custom attribute codes that have a frontend label value defined
+                $attributesArray[$attribute->getAttributeCode()] = array(
+                    'value' => $attribute->getAttributeCode(),
+                    'label' => __($label)
+                );
+            }
+        }
+
+        // Sort alphabetically for ease of use
+        sort($attributesArray);
+
+        return $attributesArray;
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -186,7 +186,7 @@
                 <field id="customer_code_format" translate="label comment" type="select" sortOrder="3010" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Customer Code Format</label>
                     <source_model>ClassyLlama\AvaTax\Model\Config\Source\CustomerCode</source_model>
-                    <comment>Select a format for customers to be identified in AvaTax.  Once the integration is live, this setting should not be changed.</comment>
+                    <comment><![CDATA[Select a format for customers to be identified in AvaTax. Available options will include any <em>custom</em> customer attributes that have been created in Magento. If the customer doesn't have a value defined for the selected attribute when their transaction is processed and sent to Avalara, their customer (or guest) ID will be used instead. Once the integration is live, this setting should not be changed.]]></comment>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -54,6 +54,7 @@
                 <queue_failed_lifetime>180</queue_failed_lifetime>
                 <queue_admin_notification_enabled>1</queue_admin_notification_enabled>
                 <queue_failure_notification_enabled>1</queue_failure_notification_enabled>
+                <customer_code_format>id</customer_code_format>
             </avatax>
         </tax>
     </default>


### PR DESCRIPTION
AVS-421_74 - Expand Customer Code config setting to include custom customer attributes

- Addresses issue #99 
- Add custom customer attributes to customer code option list
- Refactor queue processor to use custom attribute codes when defined
  and selected
- Update comment on config setting in admin
- Define default value for config setting