### PR TITLE
Fixed BP constant issue in registration.php

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -9,5 +9,5 @@
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::LIBRARY,
     'Avalara_AvaTax',
-    BP . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'avalara' . DIRECTORY_SEPARATOR . 'avatax'
+    __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'avalara' . DIRECTORY_SEPARATOR . 'avatax'
 );

--- a/registration.php
+++ b/registration.php
@@ -6,8 +6,16 @@
     __DIR__
 );
 
+if (defined('BP')) {
+    // This path will work when extension is installed via composer or via manual installation
+    $vendorPath = BP . DIRECTORY_SEPARATOR . 'vendor';
+} else {
+    // This path will work when extension is being run in the context of integration tests, where BP is not defined
+    $vendorPath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..';
+}
+
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::LIBRARY,
     'Avalara_AvaTax',
-    __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'avalara' . DIRECTORY_SEPARATOR . 'avatax'
+    $vendorPath . DIRECTORY_SEPARATOR . 'avalara' . DIRECTORY_SEPARATOR . 'avatax'
 );


### PR DESCRIPTION
This PR fixes issue when running CLI tools like PHPUnit, PHPMD or PHPCS. Composer is autoloading registration.php, but app/autoload.php isn't loaded there so BP constant is not available.

To reproduce try to run
```
php bin/magento dev:tests:run unit
```
It will throw an error
```
PHP Notice:  Use of undefined constant BP - assumed 'BP' in .../vendor/classyllama/module-avatax/registration.php on line 12
```