### PR TITLE
$item->getOrderItem()->getProductId() had to be changed in two places

### DIFF
--- a/Helper/TaxClass.php
+++ b/Helper/TaxClass.php
@@ -254,7 +254,7 @@ class TaxClass
         }
 
         foreach ($items as $item) {
-            $productId = $item->getOrderItem()->getProduct()->getId();
+            $productId = $item->getOrderItem()->getProductId();
             if (isset($productsById[$productId])) {
                 $productWithCorrectTaxClassId = $productsById[$productId];
                 if ($productWithCorrectTaxClassId->getTaxClassId()) {


### PR DESCRIPTION
Cron job is still throwing errors after upgrading to latest version. The issue seems to be that $item->getOrderItem()->getProductId() was fixed on line 241 but not on line 257.