### PR TITLE
Fatal error when cron runs because $product is null

### DIFF
--- a/Framework/Interaction/Line.php
+++ b/Framework/Interaction/Line.php
@@ -167,6 +167,10 @@ class Line
             return false;
         }
         $product = $item->getOrderItem()->getProduct();
+        
+        if ($product === null) {
+            return false;
+        }
 
         $itemCode = $this->taxClassHelper->getItemCodeOverride($product);
         if (!$itemCode) {
@@ -215,6 +219,10 @@ class Line
 
         $product = $item->getOrderItem()->getProduct();
 
+        if ($product === null) {
+            return false;
+        }
+        
         $itemCode = $this->taxClassHelper->getItemCodeOverride($product);
         if (!$itemCode) {
             $itemCode = $item->getSku();


### PR DESCRIPTION
Sometimes getOrderItem()->getProduct() returns null and causes the cron to err out. This prevents the fatal error.

This may only be happening on our development environments due to messy data, but I added this code so I could get your module through our internal QA process. I'm not sure if it's the best fix, but it worked for what I needed. I've starred your repo so that I get notified of any future changes that need to be applied. Thanks for the great work on this!