### PR TITLE
Don't disable validation if it wasn't intentionally

### DIFF
--- a/Plugin/Checkout/Model/ShippingInformationManagement.php
+++ b/Plugin/Checkout/Model/ShippingInformationManagement.php
@@ -165,9 +165,10 @@ class ShippingInformationManagement
         $quoteAddress = null;
 
         $shouldValidateAddress = true;
-        if (!is_null($shippingInformationExtension)
-            && ($shippingInformationExtension->getShouldValidateAddress() !== null)) {
-
+        if (
+            !is_null($shippingInformationExtension)
+            && $shippingInformationExtension->getShouldValidateAddress() !== null
+        ) {
             $shouldValidateAddress = $shippingInformationExtension->getShouldValidateAddress();
         }
 

--- a/Plugin/Checkout/Model/ShippingInformationManagement.php
+++ b/Plugin/Checkout/Model/ShippingInformationManagement.php
@@ -165,7 +165,9 @@ class ShippingInformationManagement
         $quoteAddress = null;
 
         $shouldValidateAddress = true;
-        if (!is_null($shippingInformationExtension)) {
+        if (!is_null($shippingInformationExtension)
+            && ($shippingInformationExtension->getShouldValidateAddress() !== null)) {
+
             $shouldValidateAddress = $shippingInformationExtension->getShouldValidateAddress();
         }
 


### PR DESCRIPTION
Extension Attributes is an object to store [various third-party modules data](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js#L9).

So, it may not be null, but the code will disable validation in this case.

The patch fixes this logic and changes `$shouldValidateAddress` flag, if `getShouldValidateAddress` is set.
