### PR TITLE
AVA-555_38-cross-border-type-qafix override cb type id to text value

### DIFF
--- a/Api/Data/CrossBorderClassInterface.php
+++ b/Api/Data/CrossBorderClassInterface.php
@@ -24,6 +24,7 @@ interface CrossBorderClassInterface
     const UNIT_NAME = 'unit_name';
     const UNIT_AMOUNT = 'unit_amount_product_attr';
     const PREF_PROGRAM_IND = 'pref_program_indicator';
+    const NO_CROSS_BORDER_TYPE_TEXT = 'Unknown';
 
     /**
      * Get cross border class ID

--- a/Ui/Component/Listing/Columns/CrossBorderClassActions.php
+++ b/Ui/Component/Listing/Columns/CrossBorderClassActions.php
@@ -20,6 +20,7 @@ use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Ui\Component\Listing\Columns\Column;
 use Magento\Framework\UrlInterface;
 use ClassyLlama\AvaTax\Model\CrossBorderTypeRepository;
+use ClassyLlama\AvaTax\Api\Data\CrossBorderClassInterface;
 
 class CrossBorderClassActions extends Column
 {
@@ -31,7 +32,7 @@ class CrossBorderClassActions extends Column
     protected $urlBuilder;
 
     /**
-     * @var
+     * @var CrossBorderTypeRepository
      */
     protected $crossBorderTypeRepository;
 
@@ -69,9 +70,10 @@ class CrossBorderClassActions extends Column
                 /**
                  * overriding cross border type id int with the label
                  */
-                if(isset($item['cross_border_type_id'])) {
-                    $item['cross_border_type_id'] = $this->fetchCrossBorderTypeValue(
-                        $item['cross_border_type_id']
+                if(isset($item[CrossBorderClassInterface::CROSS_BORDER_TYPE])) {
+
+                    $item[CrossBorderClassInterface::CROSS_BORDER_TYPE] = $this->fetchCrossBorderTypeValue(
+                        $item[CrossBorderClassInterface::CROSS_BORDER_TYPE]
                     );
                 }
 
@@ -87,14 +89,14 @@ class CrossBorderClassActions extends Column
     }
 
     /**
-     * @param int $type_id
+     * returns the text value of the Cross Border Type Id
+     *
+     * @param $type_id
      *
      * @return null|string
-     * @throws \Magento\Framework\Exception\LocalizedException
      */
-    protected function fetchCrossBorderTypeValue(int $type_id)
+    protected function fetchCrossBorderTypeValue($type_id)
     {
-        $type_object = $this->crossBorderTypeRepository->getById($type_id);
-        return $type_object->getType();
+        return $this->crossBorderTypeRepository->getById($type_id)->getType();
     }
 }

--- a/Ui/Component/Listing/Columns/CrossBorderClassActions.php
+++ b/Ui/Component/Listing/Columns/CrossBorderClassActions.php
@@ -77,7 +77,7 @@ class CrossBorderClassActions extends Column
                             $item[CrossBorderClassInterface::CROSS_BORDER_TYPE]
                         );
                     } catch (LocalizedException $e) {
-                        $item[CrossBorderClassInterface::CROSS_BORDER_TYPE] = 'N/A';
+                        $item[CrossBorderClassInterface::CROSS_BORDER_TYPE] = CrossBorderClassInterface::NO_CROSS_BORDER_TYPE_TEXT;
                     }
                 }
 

--- a/Ui/Component/Listing/Columns/CrossBorderClassActions.php
+++ b/Ui/Component/Listing/Columns/CrossBorderClassActions.php
@@ -15,6 +15,7 @@
 
 namespace ClassyLlama\AvaTax\Ui\Component\Listing\Columns;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Ui\Component\Listing\Columns\Column;
@@ -71,10 +72,13 @@ class CrossBorderClassActions extends Column
                  * overriding cross border type id int with the label
                  */
                 if(isset($item[CrossBorderClassInterface::CROSS_BORDER_TYPE])) {
-
-                    $item[CrossBorderClassInterface::CROSS_BORDER_TYPE] = $this->fetchCrossBorderTypeValue(
-                        $item[CrossBorderClassInterface::CROSS_BORDER_TYPE]
-                    );
+                    try {
+                        $item[CrossBorderClassInterface::CROSS_BORDER_TYPE] = $this->fetchCrossBorderTypeValue(
+                            $item[CrossBorderClassInterface::CROSS_BORDER_TYPE]
+                        );
+                    } catch (LocalizedException $e) {
+                        $item[CrossBorderClassInterface::CROSS_BORDER_TYPE] = 'N/A';
+                    }
                 }
 
                 $item[$this->getData('name')]['view'] = [
@@ -91,12 +95,13 @@ class CrossBorderClassActions extends Column
     /**
      * returns the text value of the Cross Border Type Id
      *
-     * @param $type_id
+     * @param $typeId
      *
      * @return null|string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
-    protected function fetchCrossBorderTypeValue($type_id)
+    protected function fetchCrossBorderTypeValue($typeId)
     {
-        return $this->crossBorderTypeRepository->getById($type_id)->getType();
+        return $this->crossBorderTypeRepository->getById($typeId)->getType();
     }
 }

--- a/Ui/Component/Listing/Columns/CrossBorderClassActions.php
+++ b/Ui/Component/Listing/Columns/CrossBorderClassActions.php
@@ -19,6 +19,7 @@ use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Ui\Component\Listing\Columns\Column;
 use Magento\Framework\UrlInterface;
+use ClassyLlama\AvaTax\Model\CrossBorderTypeRepository;
 
 class CrossBorderClassActions extends Column
 {
@@ -28,6 +29,11 @@ class CrossBorderClassActions extends Column
      * @var UrlInterface
      */
     protected $urlBuilder;
+
+    /**
+     * @var
+     */
+    protected $crossBorderTypeRepository;
 
     /**
      * @param ContextInterface $context
@@ -40,10 +46,12 @@ class CrossBorderClassActions extends Column
         ContextInterface $context,
         UiComponentFactory $uiComponentFactory,
         UrlInterface $urlBuilder,
+        CrossBorderTypeRepository $crossBorderTypeRepository,
         array $components = [],
         array $data = []
     ) {
         $this->urlBuilder = $urlBuilder;
+        $this->crossBorderTypeRepository = $crossBorderTypeRepository;
         parent::__construct($context, $uiComponentFactory, $components, $data);
     }
 
@@ -57,6 +65,16 @@ class CrossBorderClassActions extends Column
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as &$item) {
+
+                /**
+                 * overriding cross border type id int with the label
+                 */
+                if(isset($item['cross_border_type_id'])) {
+                    $item['cross_border_type_id'] = $this->fetchCrossBorderTypeValue(
+                        $item['cross_border_type_id']
+                    );
+                }
+
                 $item[$this->getData('name')]['view'] = [
 
                     'href' => $this->urlBuilder->getUrl(self::URL_PATH_VIEW, ['id' => $item['class_id']]),
@@ -66,5 +84,17 @@ class CrossBorderClassActions extends Column
         }
 
         return $dataSource;
+    }
+
+    /**
+     * @param int $type_id
+     *
+     * @return null|string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function fetchCrossBorderTypeValue(int $type_id)
+    {
+        $type_object = $this->crossBorderTypeRepository->getById($type_id);
+        return $type_object->getType();
     }
 }


### PR DESCRIPTION
@LordZardeck Please review these changes to force the cross border type text value to display in the cross border class grid.

cc: @erikhansen 