### PR TITLE
Fix issue 167

### DIFF
--- a/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -22,6 +22,7 @@ define(
         'Magento_Checkout/js/model/error-processor',
         'Magento_Checkout/js/model/full-screen-loader',
         'Magento_Checkout/js/action/select-billing-address',
+        'Magento_Checkout/js/model/shipping-save-processor/payload-extender',
         'ClassyLlama_AvaTax/js/view/checkout-validation-handler',
         'Magento_Ui/js/modal/alert'
     ],
@@ -35,6 +36,7 @@ define(
         errorProcessor,
         fullScreenLoader,
         selectBillingAddressAction,
+        payloadExtender,
         checkoutValidationHandler,
         alert
     ) {
@@ -57,6 +59,8 @@ define(
                         shipping_carrier_code: quote.shippingMethod().carrier_code
                     }
                 };
+
+                payloadExtender(payload);
 
                 fullScreenLoader.startLoader();
 


### PR DESCRIPTION
Includes the Magento checkout payload extender in the default shipping save processor.

View [issue 167](https://github.com/classyllama/ClassyLlama_AvaTax/issues/167) for more information. 