### PR TITLE
[#178] Added sensitive and environment-specific entries to the configuration type pool

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -135,4 +135,29 @@
             <argument name="connectionName" xsi:type="string">sales</argument>
         </arguments>
     </type>
+
+    <!--
+    /**
+     * Add sensitive and environment-specific settings to the configuration type pool.
+     * This ensures that their values are not dumped by app:config:dump in app/etc/config.php, which is usually in version control.
+     *
+     * See:
+     * - https://devdocs.magento.com/guides/v2.2/extension-dev-guide/configuration/sensitive-and-environment-settings.html
+     */
+      -->
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="sensitive" xsi:type="array">
+                <item name="tax/avatax/production_account_number" xsi:type="string">1</item>
+                <item name="tax/avatax/production_license_key" xsi:type="string">1</item>
+                <item name="tax/avatax/production_company_code" xsi:type="string">1</item>
+                <item name="tax/avatax/development_account_number" xsi:type="string">1</item>
+                <item name="tax/avatax/development_license_key" xsi:type="string">1</item>
+                <item name="tax/avatax/development_company_code" xsi:type="string">1</item>
+            </argument>
+            <argument name="environment" xsi:type="array">
+                <item name="tax/avatax/live_mode" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
The following settings were added to the sensitive configuration type pool:
- ```tax/avatax/production_account_number```
- ```tax/avatax/production_license_key```
- ```tax/avatax/production_company_code```
- ```tax/avatax/development_account_number```
- ```tax/avatax/development_license_key```
- ```tax/avatax/development_company_code```

The following setting was added to the environment-specific configuration type pool:
- ```tax/avatax/live_mode```

Testing was done manually to ensure that ```bin/magento app:config:dump``` saves these settings into ```app/etc/env.php``` and not ```app/etc/config```. The code worked as expected.