### PR TITLE
AVS-421_116 - Start structure and functionality for AssociatedTaxables

### DIFF
--- a/Api/AssociatedTaxableRepositoryInterface.php
+++ b/Api/AssociatedTaxableRepositoryInterface.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Api;
+
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterface;
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableSearchResultsInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+
+interface AssociatedTaxableRepositoryInterface
+{
+    /**
+     * @param integer $associatedTaxableId
+     *
+     * @return AssociatedTaxableInterface
+     */
+    public function getById($associatedTaxableId);
+
+    /**
+     * @param AssociatedTaxableInterface $associatedTaxable
+     *
+     * @return AssociatedTaxableInterface
+     */
+    public function save(AssociatedTaxableInterface $associatedTaxable);
+
+    /**
+     * @param SearchCriteriaInterface $searchCriteria
+     *
+     * @return AssociatedTaxableSearchResultsInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria);
+
+    /**
+     * @param $associatedTaxableId
+     *
+     * @return bool true on success
+     */
+    public function deleteById($associatedTaxableId);
+
+    /**
+     * @param integer $orderId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getQuoteAssociatedTaxablesForOrder($orderId);
+
+    /**
+     * @param integer $orderId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getItemAssociatedTaxablesForOrder($orderId);
+
+    /**
+     * @param integer $invoiceId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getAllAssociatedTaxablesForInvoice($invoiceId);
+}

--- a/Api/AssociatedTaxableRepositoryInterface.php
+++ b/Api/AssociatedTaxableRepositoryInterface.php
@@ -60,4 +60,11 @@ interface AssociatedTaxableRepositoryInterface
      * @return AssociatedTaxableInterface[]
      */
     public function getAllAssociatedTaxablesForInvoice($invoiceId);
+
+    /**
+     * @param integer $creditMemoId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getAllAssociatedTaxablesForCreditMemo($creditMemoId);
 }

--- a/Api/Data/AssociatedTaxableInterface.php
+++ b/Api/Data/AssociatedTaxableInterface.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Api\Data;
+
+interface AssociatedTaxableInterface
+{
+    const ID = 'id';
+    const ORDER_ITEM_ID = 'order_item_id';
+    const INVOICE_ID = 'invoice_id';
+    const ORDER_ID = 'order_id';
+    const CREDIT_MEMO_ID = 'credit_memo_id';
+    const ITEM_ID = 'item_id';
+    const TYPE = 'type';
+    const CODE = 'code';
+    const UNIT_PRICE = 'unit_price';
+    const BASE_UNIT_PRICE = 'base_unit_price';
+    const QUANTITY = 'quantity';
+    const TAX_CLASS_ID = 'tax_class_id';
+    const PRICE_INCLUDES_TAX = 'price_includes_tax';
+    const ASSOCIATED_ITEM_CODE = 'associated_item_code';
+
+    /**
+     * @return integer
+     */
+    public function getId();
+
+    /**
+     * @param $id
+     *
+     * @return $this
+     */
+    public function setId($id);
+
+    /**
+     * @return integer
+     */
+    public function getOrderItemId();
+
+    /**
+     * @param integer $orderItemId
+     *
+     * @return $this
+     */
+    public function setOrderItemId($orderItemId);
+
+    /**
+     * @return integer
+     */
+    public function getOrderId();
+
+    /**
+     * @param integer $orderId
+     *
+     * @return $this
+     */
+    public function setOrderId($orderId);
+
+    /**
+     * @return integer
+     */
+    public function getInvoiceId();
+
+    /**
+     * @param integer $invoiceId
+     *
+     * @return $this
+     */
+    public function setInvoiceId($invoiceId);
+
+    /**
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * @param string $type
+     *
+     * @return $this
+     */
+    public function setType($type);
+
+    /**
+     * @return string
+     */
+    public function getCode();
+
+    /**
+     * @param string $code
+     *
+     * @return $this
+     */
+    public function setCode($code);
+
+    /**
+     * @return float
+     */
+    public function getUnitPrice();
+
+    /**
+     * @param float $unitPrice
+     *
+     * @return $this
+     */
+    public function setUnitPrice($unitPrice);
+
+    /**
+     * @return float
+     */
+    public function getBaseUnitPrice();
+
+    /**
+     * @param float $baseUnitPrice
+     *
+     * @return $this
+     */
+    public function setBaseUnitPrice($baseUnitPrice);
+
+    /**
+     * @return integer
+     */
+    public function getQuantity();
+
+    /**
+     * @param integer $quantity
+     *
+     * @return $this
+     */
+    public function setQuantity($quantity);
+
+    /**
+     * @return string
+     */
+    public function getTaxClassId();
+
+    /**
+     * @param string $taxClassId
+     *
+     * @return $this
+     */
+    public function setTaxClassId($taxClassId);
+
+    /**
+     * @return bool
+     */
+    public function getPriceIncludesTax();
+
+    /**
+     * @param bool $priceIncludesTax
+     *
+     * @return $this
+     */
+    public function setPriceIncludesTax($priceIncludesTax);
+
+    /**
+     * @return string
+     */
+    public function getAssociatedItemCode();
+
+    /**
+     * @param string $associatedItemCode
+     *
+     * @return $this
+     */
+    public function setAssociatedItemCode($associatedItemCode);
+}

--- a/Api/Data/AssociatedTaxableInterface.php
+++ b/Api/Data/AssociatedTaxableInterface.php
@@ -166,4 +166,16 @@ interface AssociatedTaxableInterface
      * @return $this
      */
     public function setAssociatedItemCode($associatedItemCode);
+
+    /**
+     * @return integer
+     */
+    public function getCreditMemoId();
+
+    /**
+     * @param integer $creditMemoId
+     *
+     * @return $this
+     */
+    public function setCreditMemoId($creditMemoId);
 }

--- a/Api/Data/AssociatedTaxableSearchResultsInterface.php
+++ b/Api/Data/AssociatedTaxableSearchResultsInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Api\Data;
+
+use Magento\Framework\Api\SearchResultsInterface;
+
+interface AssociatedTaxableSearchResultsInterface extends SearchResultsInterface
+{
+    /**
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getItems();
+
+    /**
+     * @param AssociatedTaxableInterface[] $items
+     *
+     * @return $this
+     */
+    public function setItems(array $items);
+}

--- a/Api/SearchCriteria/JoinProcessor/Order.php
+++ b/Api/SearchCriteria/JoinProcessor/Order.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Api\SearchCriteria\JoinProcessor;
+
+use Magento\Framework\Data\Collection\AbstractDb as DbCollection;
+use \Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor\CustomJoinInterface;
+
+class Order implements CustomJoinInterface
+{
+
+    /**
+     * Make custom joins to collection
+     *
+     * @param DbCollection $collection
+     *
+     * @return bool
+     * @since 100.2.0
+     */
+    public function apply(DbCollection $collection)
+    {
+        /** @var \Magento\Framework\DB\Adapter\AdapterInterface $connection */
+        $connection = $collection->getConnection();
+
+        $collection->getSelect()->joinInner(
+            ['soi' => $connection->getTableName('sales_order_item')],
+            new \Zend_Db_Expr('main_table.order_item_id=soi.item_id'),
+            ['sales_order_id' => 'order_id']
+        );
+        return true;
+    }
+}

--- a/Api/SearchCriteria/JoinProcessor/Order.php
+++ b/Api/SearchCriteria/JoinProcessor/Order.php
@@ -25,7 +25,7 @@ class Order implements CustomJoinInterface
         /** @var \Magento\Framework\DB\Adapter\AdapterInterface $connection */
         $connection = $collection->getConnection();
 
-        $collection->getSelect()->joinInner(
+        $collection->getSelect()->joinLeft(
             ['soi' => $connection->getTableName('sales_order_item')],
             new \Zend_Db_Expr('main_table.order_item_id=soi.item_id'),
             ['sales_order_id' => 'order_id']

--- a/Framework/Interaction/Line.php
+++ b/Framework/Interaction/Line.php
@@ -243,9 +243,11 @@ class Line
     /**
      * @param AssociatedTaxableInterface $item
      *
+     * @param bool                       $isCreditMemo
+     *
      * @return array
      */
-    protected function convertAssociatedTaxableItemToData(AssociatedTaxableInterface $item)
+    public function getAssociatedTaxableLine(AssociatedTaxableInterface $item, $isCreditMemo = false)
     {
         $avataxCode = $this->taxClassHelper->getAvaTaxTaxCode($item->getTaxClassId());
         return [
@@ -254,7 +256,7 @@ class Line
             'TaxCode' => $avataxCode,
             'Description' => $item->getCode(),
             'Qty' => $item->getQuantity(),
-            'Amount' => $item->getUnitPrice() * $item->getQuantity(), // TODO: Verify this should be price * quantity
+            'Amount' => $item->getUnitPrice() * $item->getQuantity() * ($isCreditMemo ? -1 : 1),
             'Discounted' => false,
             'TaxIncluded' => (bool)$item->getPriceIncludesTax()
         ];
@@ -319,9 +321,6 @@ class Line
                 break;
             case ($data instanceof \Magento\Sales\Api\Data\CreditmemoItemInterface):
                 $data = $this->convertCreditMemoItemToData($data);
-                break;
-            case ($data instanceof AssociatedTaxableInterface):
-                $data = $this->convertAssociatedTaxableItemToData($data);
                 break;
             case (!is_array($data)):
                 return false;

--- a/Framework/Interaction/Line.php
+++ b/Framework/Interaction/Line.php
@@ -245,14 +245,14 @@ class Line
      *
      * @param bool                       $isCreditMemo
      *
-     * @return array
+     * @return \AvaTax\Line
      */
     public function getAssociatedTaxableLine(AssociatedTaxableInterface $item, $isCreditMemo = false)
     {
         $avataxCode = $this->taxClassHelper->getAvaTaxTaxCode($item->getTaxClassId());
-        return [
+        $data = [
             'No'=> $this->getLineNumber(),
-            'ItemCode' => $item->getAssociatedItemCode(),
+            'ItemCode' => $item->getCode(),
             'TaxCode' => $avataxCode,
             'Description' => $item->getCode(),
             'Qty' => $item->getQuantity(),
@@ -260,6 +260,12 @@ class Line
             'Discounted' => false,
             'TaxIncluded' => (bool)$item->getPriceIncludesTax()
         ];
+
+        /** @var $line \AvaTax\Line */
+        $line = $this->lineFactory->create();
+
+        $this->populateLine($data, $line);
+        return $line;
     }
 
     /**

--- a/Helper/AssociatedTaxable.php
+++ b/Helper/AssociatedTaxable.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Helper;
+
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\GiftWrapping\Model\Total\Quote\Tax\Giftwrapping;
+use Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector;
+
+class AssociatedTaxable extends AbstractHelper
+{
+
+    /**
+     * @var Config
+     */
+    protected $configHelper;
+
+    /**
+     * @var TaxClass
+     */
+    protected $taxClassHelper;
+
+    /**
+     * @param Context  $context
+     * @param Config   $configHelper
+     * @param TaxClass $taxClassHelper
+     */
+    public function __construct(
+        Context $context,
+        \ClassyLlama\AvaTax\Helper\Config $configHelper,
+        \ClassyLlama\AvaTax\Helper\TaxClass $taxClassHelper
+    ) {
+        parent::__construct($context);
+        $this->configHelper = $configHelper;
+        $this->taxClassHelper = $taxClassHelper;
+    }
+
+    /**
+     * @param array $associatedTaxableData
+     *
+     * @param       $storeId
+     *
+     * @return array
+     */
+    public function updateData($associatedTaxableData, $storeId)
+    {
+        $data = $associatedTaxableData;
+        $type = $associatedTaxableData[CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_TYPE];
+        switch ($type) {
+            case Giftwrapping::ITEM_TYPE:
+                $data = $this->handleGiftWrappingItem($associatedTaxableData, $storeId);
+                break;
+            case Giftwrapping::QUOTE_TYPE:
+                $data = $this->handleGiftWrappingQuote($data, $storeId);
+                break;
+            case Giftwrapping::PRINTED_CARD_TYPE:
+                $data = $this->handlePrintedCard($data, $storeId);
+                break;
+            default:
+                break;
+        }
+        return $data;
+    }
+
+    /**
+     * @param $data
+     * @param $storeId
+     *
+     * @return array
+     */
+    public function handleGiftWrappingItem($data, $storeId)
+    {
+        $itemCode = $this->configHelper->getSkuShippingGiftWrapItem($storeId);
+        $taxClassId = $this->taxClassHelper->getAvataxTaxClassIdForGiftOptions($storeId);
+        // TODO: Description?
+        $data[CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_CODE] = $itemCode;
+        $data[CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_TAX_CLASS_ID] = $taxClassId;
+        return $data;
+    }
+
+    /**
+     * @param $data
+     * @param $storeId
+     *
+     * @return array
+     */
+    public function handleGiftWrappingQuote($data, $storeId)
+    {
+        $itemCode = $this->configHelper->getSkuGiftWrapOrder($storeId);
+        $taxClassId = $this->taxClassHelper->getAvataxTaxClassIdForGiftOptions($storeId);
+        $data[CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_CODE] = $itemCode;
+        $data[CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_TAX_CLASS_ID] = $taxClassId;
+        return $data;
+    }
+
+    /**
+     * @param $data
+     * @param $storeId
+     *
+     * @return array
+     */
+    public function handlePrintedCard($data, $storeId)
+    {
+        $itemCode = $this->configHelper->getSkuShippingGiftWrapCard($storeId);
+        $taxClassId = $this->taxClassHelper->getAvataxTaxClassIdForGiftOptions($storeId);
+        $data[CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_CODE] = $itemCode;
+        $data[CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_TAX_CLASS_ID] = $taxClassId;
+        return $data;
+    }
+}

--- a/Helper/TaxClass.php
+++ b/Helper/TaxClass.php
@@ -104,7 +104,7 @@ class TaxClass
      * @param int $taxClassId
      * @return string|null
      */
-    protected function getAvaTaxTaxCode($taxClassId)
+    public function getAvaTaxTaxCode($taxClassId)
     {
         try {
             $taxClass = $this->taxClassRepository->get($taxClassId);
@@ -191,12 +191,22 @@ class TaxClass
      */
     public function getAvataxTaxCodeForGiftOptions($store)
     {
-        $taxClassId = $this->scopeConfig->getValue(
+        $taxClassId = $this->getAvataxTaxClassIdForGiftOptions($store);
+        return $this->getAvaTaxTaxCode($taxClassId);
+    }
+
+    /**
+     * @param $store
+     *
+     * @return string|null
+     */
+    public function getAvataxTaxClassIdForGiftOptions($store)
+    {
+        return $this->scopeConfig->getValue(
             self::XML_PATH_TAX_CLASS_GIFT_WRAPPING,
             ScopeInterface::SCOPE_STORE,
             $store
         );
-        return $this->getAvaTaxTaxCode($taxClassId);
     }
 
     /**

--- a/Model/ResourceModel/Tax/AssociatedTaxable.php
+++ b/Model/ResourceModel/Tax/AssociatedTaxable.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Model\ResourceModel\Tax;
+
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class AssociatedTaxable extends AbstractDb
+{
+    /**
+     * Resource initialization
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('avatax_associated_taxables', AssociatedTaxableInterface::ID);
+    }
+}

--- a/Model/ResourceModel/Tax/AssociatedTaxable/Collection.php
+++ b/Model/ResourceModel/Tax/AssociatedTaxable/Collection.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxable;
+
+use ClassyLlama\AvaTax\Model\Tax\AssociatedTaxable;
+
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+{
+    /**
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init(AssociatedTaxable::class, \ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxable::class);
+    }
+}

--- a/Model/Tax/AssociatedTaxable.php
+++ b/Model/Tax/AssociatedTaxable.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Model\Tax;
+
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterface;
+
+class AssociatedTaxable extends \Magento\Framework\Model\AbstractModel implements AssociatedTaxableInterface
+{
+
+    public function _construct()
+    {
+        $this->_init(\ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxable::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->_getData(AssociatedTaxableInterface::ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrderItemId()
+    {
+        return $this->_getData(AssociatedTaxableInterface::ORDER_ITEM_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrderId()
+    {
+        return $this->_getData(AssociatedTaxableInterface::ORDER_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInvoiceId()
+    {
+        return $this->_getData(AssociatedTaxableInterface::INVOICE_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItemId()
+    {
+        return $this->_getData(AssociatedTaxableInterface::ITEM_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return $this->_getData(AssociatedTaxableInterface::TYPE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCode()
+    {
+        return $this->_getData(AssociatedTaxableInterface::CODE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnitPrice()
+    {
+        return $this->_getData(AssociatedTaxableInterface::UNIT_PRICE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseUnitPrice()
+    {
+        return $this->_getData(AssociatedTaxableInterface::BASE_UNIT_PRICE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuantity()
+    {
+        return $this->_getData(AssociatedTaxableInterface::QUANTITY);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTaxClassId()
+    {
+        return $this->_getData(AssociatedTaxableInterface::TAX_CLASS_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriceIncludesTax()
+    {
+        return $this->_getData(AssociatedTaxableInterface::PRICE_INCLUDES_TAX);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAssociatedItemCode()
+    {
+        return $this->_getData(AssociatedTaxableInterface::ASSOCIATED_ITEM_CODE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreditMemoId()
+    {
+        return $this->_getData(AssociatedTaxableInterface::CREDIT_MEMO_ID);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOrderItemId($orderItemId)
+    {
+        return $this->setData(AssociatedTaxableInterface::ORDER_ITEM_ID, $orderItemId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOrderId($orderId)
+    {
+        return $this->setData(AssociatedTaxableInterface::ORDER_ID, $orderId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setInvoiceId($invoiceId)
+    {
+        return $this->setData(AssociatedTaxableInterface::INVOICE_ID, $invoiceId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setItemId($itemId)
+    {
+        return $this->setData(AssociatedTaxableInterface::ITEM_ID, $itemId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setType($type)
+    {
+        return $this->setData(AssociatedTaxableInterface::TYPE, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCode($code)
+    {
+        return $this->setData(AssociatedTaxableInterface::CODE, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUnitPrice($unitPrice)
+    {
+        return $this->setData(AssociatedTaxableInterface::UNIT_PRICE, $unitPrice);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBaseUnitPrice($baseUnitPrice)
+    {
+        return $this->setData(AssociatedTaxableInterface::BASE_UNIT_PRICE, $baseUnitPrice);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setQuantity($quantity)
+    {
+        return $this->setData(AssociatedTaxableInterface::QUANTITY, $quantity);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTaxClassId($taxClassId)
+    {
+        return $this->setData(AssociatedTaxableInterface::TAX_CLASS_ID, $taxClassId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriceIncludesTax($priceIncludesTax)
+    {
+        return $this->setData(AssociatedTaxableInterface::PRICE_INCLUDES_TAX, $priceIncludesTax);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAssociatedItemCode($associatedItemCode)
+    {
+        return $this->setData(AssociatedTaxableInterface::ASSOCIATED_ITEM_CODE, $associatedItemCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCreditMemoId($creditMemoId)
+    {
+        return $this->setData(AssociatedTaxableInterface::CREDIT_MEMO_ID, $creditMemoId);
+    }
+}

--- a/Model/Tax/AssociatedTaxableRepository.php
+++ b/Model/Tax/AssociatedTaxableRepository.php
@@ -181,32 +181,20 @@ class AssociatedTaxableRepository implements AssociatedTaxableRepositoryInterfac
         /** @var \Magento\Framework\Api\Filter $orderIdFilter */
         $orderIdFilter = $this->filterBuilder->create();
 
-        $this->filterBuilder->setField(AssociatedTaxableInterface::ASSOCIATED_ITEM_CODE);
-        $this->filterBuilder->setValue(CommonTaxCollector::ASSOCIATION_ITEM_CODE_FOR_QUOTE);
-        $this->filterBuilder->setConditionType('neq');
-        /** @var \Magento\Framework\Api\Filter $quoteNotItemFilter */
-        $quoteNotItemFilter = $this->filterBuilder->create();
-
-        $this->filterBuilder->setField(AssociatedTaxableInterface::ASSOCIATED_ITEM_CODE);
+        $this->filterBuilder->setField(AssociatedTaxableInterface::ORDER_ITEM_ID);
         $this->filterBuilder->setValue(null);
-        $this->filterBuilder->setConditionType('null');
+        $this->filterBuilder->setConditionType('notnull');
 
         /** @var \Magento\Framework\Api\Filter $quoteIsNullFilter */
-        $quoteIsNullFilter = $this->filterBuilder->create();
+        $orderItemNotNull = $this->filterBuilder->create();
 
-        $this->filterGroupBuilder->addFilter($quoteNotItemFilter);
-        $this->filterGroupBuilder->addFilter($quoteIsNullFilter);
-        // filter group for item code NOT NULL or != 'quote'
-        $filterGroup = $this->filterGroupBuilder->create();
-        $this->filterGroupBuilder->addFilter($orderIdFilter);
-
-        $filterGroup2 = $this->filterGroupBuilder->create();
         /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        $searchCriteriaBuilder->addFilter($orderIdFilter);
+        $searchCriteriaBuilder->addFilter($orderItemNotNull);
 
         /** @var \Magento\Framework\Api\Search\SearchCriteria $criteria */
         $criteria = $searchCriteriaBuilder->create();
-        $criteria->setFilterGroups([$filterGroup, $filterGroup2]);
 
         return $this->getList($criteria)->getItems();
     }

--- a/Model/Tax/AssociatedTaxableRepository.php
+++ b/Model/Tax/AssociatedTaxableRepository.php
@@ -176,7 +176,7 @@ class AssociatedTaxableRepository implements AssociatedTaxableRepositoryInterfac
      */
     public function getItemAssociatedTaxablesForOrder($orderId)
     {
-        $this->filterBuilder->setField('soi.order_id');
+        $this->filterBuilder->setField(AssociatedTaxableInterface::ORDER_ID);
         $this->filterBuilder->setValue($orderId);
         /** @var \Magento\Framework\Api\Filter $orderIdFilter */
         $orderIdFilter = $this->filterBuilder->create();
@@ -203,7 +203,6 @@ class AssociatedTaxableRepository implements AssociatedTaxableRepositoryInterfac
         $filterGroup2 = $this->filterGroupBuilder->create();
         /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
-        $searchCriteriaBuilder->addFilter($orderIdFilter);
 
         /** @var \Magento\Framework\Api\Search\SearchCriteria $criteria */
         $criteria = $searchCriteriaBuilder->create();

--- a/Model/Tax/AssociatedTaxableRepository.php
+++ b/Model/Tax/AssociatedTaxableRepository.php
@@ -226,4 +226,19 @@ class AssociatedTaxableRepository implements AssociatedTaxableRepositoryInterfac
         $searchCriteriaBuilder->addFilter($this->filterBuilder->create());
         return $this->getList($searchCriteriaBuilder->create())->getItems();
     }
+
+    /**
+     * @param int $creditMemoId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getAllAssociatedTaxablesForCreditMemo($creditMemoId)
+    {
+        $this->filterBuilder->setField(AssociatedTaxableInterface::CREDIT_MEMO_ID);
+        $this->filterBuilder->setValue($creditMemoId);
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        $searchCriteriaBuilder->addFilter($this->filterBuilder->create());
+        return $this->getList($searchCriteriaBuilder->create())->getItems();
+    }
 }

--- a/Model/Tax/AssociatedTaxableRepository.php
+++ b/Model/Tax/AssociatedTaxableRepository.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Model\Tax;
+
+use ClassyLlama\AvaTax\Api\AssociatedTaxableRepositoryInterface;
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterface;
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterfaceFactory as AssociatedTaxableFactory;
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableSearchResultsInterface;
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableSearchResultsInterfaceFactory;
+use ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxable\Collection;
+use ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxable\CollectionFactory;
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\Search\FilterGroupBuilder;
+use Magento\Framework\Api\Search\SearchCriteriaBuilder;
+use Magento\Framework\Api\Search\SearchCriteriaBuilderFactory;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector;
+
+class AssociatedTaxableRepository implements AssociatedTaxableRepositoryInterface
+{
+    protected $filterGroupBuilder;
+
+    /**
+     * @var FilterBuilder
+     */
+    protected $filterBuilder;
+
+    /**
+     * @var \ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxable
+     */
+    protected $resource;
+
+    /**
+     * @var AssociatedTaxableFactory
+     */
+    protected $associatedTaxableModelFactory;
+
+    /**
+     * @var AssociatedTaxableSearchResultsInterfaceFactory
+     */
+    protected $associatedTaxableSearchResultsFactory;
+
+    /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+
+    /**
+     * @var \Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface
+     */
+    protected $collectionProcessor;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    protected $searchCriteriaBuilderFactory;
+
+    public function __construct(
+        \ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxableFactory $resourceFactory,
+        AssociatedTaxableFactory $associatedTaxableModelFactory,
+        AssociatedTaxableSearchResultsInterfaceFactory $associatedTaxableSearchResultsInterfaceFactory,
+        CollectionFactory $collectionFactory,
+        \Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface $collectionProcessor,
+        SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        FilterBuilder $filterBuilder,
+        FilterGroupBuilder $filterGroupBuilder
+    ) {
+        $this->resource = $resourceFactory->create();
+        $this->associatedTaxableModelFactory = $associatedTaxableModelFactory;
+        $this->associatedTaxableSearchResultsFactory = $associatedTaxableSearchResultsInterfaceFactory;
+        $this->collectionFactory = $collectionFactory;
+        $this->collectionProcessor = $collectionProcessor;
+        $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+        $this->filterBuilder = $filterBuilder;
+        $this->filterGroupBuilder = $filterGroupBuilder;
+    }
+
+    /**
+     * @param integer $associatedTaxableId
+     *
+     * @return \ClassyLlama\AvaTax\Model\ResourceModel\Tax\AssociatedTaxable
+     */
+    public function getById($associatedTaxableId)
+    {
+        $model = $this->associatedTaxableModelFactory->create();
+        $entity = $this->resource->load($model, $associatedTaxableId);
+        return $entity;
+    }
+
+    /**
+     * @param AssociatedTaxableInterface $associatedTaxable
+     *
+     * @return AssociatedTaxableInterface
+     * @throws AlreadyExistsException
+     * @throws \Exception
+     */
+    public function save(AssociatedTaxableInterface $associatedTaxable)
+    {
+        $this->resource->save($associatedTaxable);
+        return $associatedTaxable;
+    }
+
+    /**
+     * @param SearchCriteriaInterface $searchCriteria
+     *
+     * @return AssociatedTaxableSearchResultsInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria)
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $this->collectionProcessor->process($searchCriteria, $collection);
+
+        /** @var AssociatedTaxableSearchResultsInterface $searchResults */
+        $searchResults = $this->associatedTaxableSearchResultsFactory->create();
+        $searchResults->setSearchCriteria($searchCriteria);
+        $searchResults->setItems($collection->getItems());
+        $searchResults->setTotalCount($collection->getSize());
+        return $searchResults;
+    }
+
+    /**
+     * @param $associatedTaxableId
+     *
+     * @return bool true on success
+     */
+    public function deleteById($associatedTaxableId)
+    {
+        $entity = $this->getById($associatedTaxableId);
+
+        try {
+            $this->resource->delete($entity);
+        } catch (\Exception $e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param integer $orderId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getQuoteAssociatedTaxablesForOrder($orderId)
+    {
+        $this->filterBuilder->setField(AssociatedTaxableInterface::ORDER_ID);
+        $this->filterBuilder->setValue($orderId);
+        /** @var \Magento\Framework\Api\Filter $orderIdFilter */
+        $orderIdFilter = $this->filterBuilder->create();
+
+        $this->filterBuilder->setField(AssociatedTaxableInterface::ASSOCIATED_ITEM_CODE);
+        $this->filterBuilder->setValue(CommonTaxCollector::ASSOCIATION_ITEM_CODE_FOR_QUOTE);
+        /** @var \Magento\Framework\Api\Filter $quoteFilter */
+        $quoteFilter = $this->filterBuilder->create();
+
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        $searchCriteriaBuilder->addFilter($quoteFilter);
+        $searchCriteriaBuilder->addFilter($orderIdFilter);
+
+        /** @var \Magento\Framework\Api\Search\SearchCriteria $criteria */
+        $criteria = $searchCriteriaBuilder->create();
+
+        return $this->getList($criteria)->getItems();
+    }
+
+    /**
+     * @param integer $orderId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getItemAssociatedTaxablesForOrder($orderId)
+    {
+        $this->filterBuilder->setField('soi.order_id');
+        $this->filterBuilder->setValue($orderId);
+        /** @var \Magento\Framework\Api\Filter $orderIdFilter */
+        $orderIdFilter = $this->filterBuilder->create();
+
+        $this->filterBuilder->setField(AssociatedTaxableInterface::ASSOCIATED_ITEM_CODE);
+        $this->filterBuilder->setValue(CommonTaxCollector::ASSOCIATION_ITEM_CODE_FOR_QUOTE);
+        $this->filterBuilder->setConditionType('neq');
+        /** @var \Magento\Framework\Api\Filter $quoteNotItemFilter */
+        $quoteNotItemFilter = $this->filterBuilder->create();
+
+        $this->filterBuilder->setField(AssociatedTaxableInterface::ASSOCIATED_ITEM_CODE);
+        $this->filterBuilder->setValue(null);
+        $this->filterBuilder->setConditionType('null');
+
+        /** @var \Magento\Framework\Api\Filter $quoteIsNullFilter */
+        $quoteIsNullFilter = $this->filterBuilder->create();
+
+        $this->filterGroupBuilder->addFilter($quoteNotItemFilter);
+        $this->filterGroupBuilder->addFilter($quoteIsNullFilter);
+        // filter group for item code NOT NULL or != 'quote'
+        $filterGroup = $this->filterGroupBuilder->create();
+        $this->filterGroupBuilder->addFilter($orderIdFilter);
+
+        $filterGroup2 = $this->filterGroupBuilder->create();
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        $searchCriteriaBuilder->addFilter($orderIdFilter);
+
+        /** @var \Magento\Framework\Api\Search\SearchCriteria $criteria */
+        $criteria = $searchCriteriaBuilder->create();
+        $criteria->setFilterGroups([$filterGroup, $filterGroup2]);
+
+        return $this->getList($criteria)->getItems();
+    }
+
+    /**
+     * @param integer $invoiceId
+     *
+     * @return AssociatedTaxableInterface[]
+     */
+    public function getAllAssociatedTaxablesForInvoice($invoiceId)
+    {
+        $this->filterBuilder->setField(AssociatedTaxableInterface::INVOICE_ID);
+        $this->filterBuilder->setValue($invoiceId);
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        $searchCriteriaBuilder->addFilter($this->filterBuilder->create());
+        return $this->getList($searchCriteriaBuilder->create())->getItems();
+    }
+}

--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -18,6 +18,7 @@ namespace ClassyLlama\AvaTax\Model\Tax\Sales\Total\Quote;
 use ClassyLlama\AvaTax\Framework\Interaction\Tax\Get\Proxy as InteractionGet;
 use ClassyLlama\AvaTax\Framework\Interaction\TaxCalculation\Proxy as TaxCalculation;
 use ClassyLlama\AvaTax\Helper\Config;
+use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
@@ -35,6 +36,16 @@ use Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory;
 
 class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
 {
+    /**
+     * @var AssociatedTaxableInterfaceFactory
+     */
+    protected $associatedTaxableFactory;
+
+    /**
+     * @var AssociatedTaxableRepository
+     */
+    protected $associatedTaxableRepository;
+
     /**
      * @var InteractionGet
      */
@@ -85,22 +96,24 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
     /**
      * Class constructor
      *
-     * @param \Magento\Tax\Model\Config $taxConfig
-     * @param \Magento\Tax\Api\TaxCalculationInterface $taxCalculationService
-     * @param QuoteDetailsInterfaceFactory $quoteDetailsDataObjectFactory
-     * @param QuoteDetailsItemInterfaceFactory $quoteDetailsItemDataObjectFactory
-     * @param TaxClassKeyInterfaceFactory $taxClassKeyDataObjectFactory
-     * @param CustomerAddressFactory $customerAddressFactory
-     * @param CustomerAddressRegionFactory $customerAddressRegionFactory
-     * @param \Magento\Tax\Helper\Data $taxData
-     * @param InteractionGet $interactionGetTax
-     * @param TaxCalculation $taxCalculation
-     * @param Config $config
-     * @param \Magento\Framework\Api\DataObjectHelper $dataObjectHelper
+     * @param \Magento\Tax\Model\Config                              $taxConfig
+     * @param \Magento\Tax\Api\TaxCalculationInterface               $taxCalculationService
+     * @param QuoteDetailsInterfaceFactory                           $quoteDetailsDataObjectFactory
+     * @param QuoteDetailsItemInterfaceFactory                       $quoteDetailsItemDataObjectFactory
+     * @param TaxClassKeyInterfaceFactory                            $taxClassKeyDataObjectFactory
+     * @param CustomerAddressFactory                                 $customerAddressFactory
+     * @param CustomerAddressRegionFactory                           $customerAddressRegionFactory
+     * @param \Magento\Tax\Helper\Data                               $taxData
+     * @param InteractionGet                                         $interactionGetTax
+     * @param TaxCalculation                                         $taxCalculation
+     * @param Config                                                 $config
+     * @param \Magento\Framework\Api\DataObjectHelper                $dataObjectHelper
      * @param \Magento\Tax\Api\Data\QuoteDetailsItemExtensionFactory $extensionFactory
-     * @param \Magento\Framework\Message\ManagerInterface $messageManager
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \ClassyLlama\AvaTax\Helper\TaxClass $taxClassHelper
+     * @param \Magento\Framework\Message\ManagerInterface            $messageManager
+     * @param \Magento\Framework\Registry                            $coreRegistry
+     * @param \ClassyLlama\AvaTax\Helper\TaxClass                    $taxClassHelper
+     * @param AssociatedTaxableFactory                               $associatedTaxableInterfaceFactory
+     * @param AssociatedTaxableRepository                            $associatedTaxableRepository
      */
     public function __construct(
         \Magento\Tax\Model\Config $taxConfig,
@@ -128,6 +141,7 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
         $this->messageManager = $messageManager;
         $this->coreRegistry = $coreRegistry;
         $this->taxClassHelper = $taxClassHelper;
+
         parent::__construct(
             $taxConfig,
             $taxCalculationService,

--- a/Observer/QuoteSubmitSuccessObserver.php
+++ b/Observer/QuoteSubmitSuccessObserver.php
@@ -81,7 +81,6 @@ class QuoteSubmitSuccessObserver implements ObserverInterface
                         $associatedTaxableData,
                         $quoteItem->getStoreId()
                     );
-                    // TODO: Handle base_currency
                     /** @var AssociatedTaxableInterface $associatedTaxable */
                     $associatedTaxable = $this->associatedTaxableFactory->create(
                         [

--- a/Observer/QuoteSubmitSuccessObserver.php
+++ b/Observer/QuoteSubmitSuccessObserver.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @category    ClassyLlama
+ * @copyright   Copyright (c) 2018 Classy Llama Studios, LLC
+ */
+
+namespace ClassyLlama\AvaTax\Observer;
+
+use ClassyLlama\AvaTax\Model\Logger\AvaTaxLogger;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterfaceFactory as AssociatedTaxableFactory;
+use ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterface;
+use ClassyLlama\AvaTax\Model\Tax\AssociatedTaxableRepository;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
+
+class QuoteSubmitSuccessObserver implements ObserverInterface
+{
+    /**
+     * @var \ClassyLlama\AvaTax\Helper\AssociatedTaxable
+     */
+    protected $associatedTaxableHelper;
+
+    /**
+     * @var AssociatedTaxableFactory
+     */
+    protected $associatedTaxableFactory;
+
+    /**
+     * @var AssociatedTaxableRepository
+     */
+    protected $associatedTaxableRepository;
+
+    /**
+     * @var AvaTaxLogger
+     */
+    protected $avataxLogger;
+
+    /**
+     * QuoteSubmitSuccessObserver constructor.
+     *
+     * @param AssociatedTaxableFactory    $associatedTaxableInterfaceFactory
+     * @param AssociatedTaxableRepository $associatedTaxableRepository
+     * @param AvaTaxLogger                $logger
+     */
+    public function __construct(
+        AssociatedTaxableFactory $associatedTaxableInterfaceFactory,
+        AssociatedTaxableRepository $associatedTaxableRepository,
+        AvaTaxLogger $logger,
+        \ClassyLlama\AvaTax\Helper\AssociatedTaxable $associatedTaxableHelper
+    ) {
+        $this->associatedTaxableFactory = $associatedTaxableInterfaceFactory;
+        $this->associatedTaxableRepository = $associatedTaxableRepository;
+        $this->avataxLogger = $logger;
+        $this->associatedTaxableHelper = $associatedTaxableHelper;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Quote $quote */
+        $quote = $observer->getQuote();
+        /** @var Order $order */
+        $order = $observer->getOrder();
+
+        $quoteItemIdOrderItemMap = [];
+        foreach ($order->getItems() as $orderItem) {
+            $quoteItemIdOrderItemMap[$orderItem->getQuoteItemId()] = $orderItem;
+        }
+        /** @var Quote\Item $quoteItem */
+        foreach ($quote->getAllItems() as $quoteItem) {
+            // item-level associated taxables
+            $associatedTaxables = $quoteItem->getAssociatedTaxables();
+            if ($associatedTaxables !== null) {
+                foreach ($associatedTaxables as $associatedTaxableData) {
+                    $associatedTaxableData = $this->associatedTaxableHelper->updateData(
+                        $associatedTaxableData,
+                        $quoteItem->getStoreId()
+                    );
+                    // TODO: Handle base_currency
+                    /** @var AssociatedTaxableInterface $associatedTaxable */
+                    $associatedTaxable = $this->associatedTaxableFactory->create(
+                        [
+                            'data' => $associatedTaxableData
+                        ]
+                    );
+                    $associatedTaxable->setInvoiceId(null);
+                    if (isset($quoteItemIdOrderItemMap[$quoteItem->getId()])) {
+                        /** @var Order\Item $orderItem */
+                        $orderItem = $quoteItemIdOrderItemMap[$quoteItem->getId()];
+                        $associatedTaxable->setOrderItemId((int)$orderItem->getId());
+                        $associatedTaxable->setOrderId($order->getId());
+                        try {
+                            $this->associatedTaxableRepository->save($associatedTaxable);
+                        } catch (\Exception $e) {
+                            $this->avataxLogger->error(
+                                "There was a problem saving associated taxable item information for order {$order->getId()}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!$quote->isVirtual()) {
+            $shippingAddress = $quote->getShippingAddress();
+            // Quote-level associated taxables
+            $associatedTaxables = $shippingAddress->getAssociatedTaxables();
+            if ($associatedTaxables !== null) {
+                foreach ($associatedTaxables as $associatedTaxableData) {
+                    $associatedTaxableData = $this->associatedTaxableHelper->updateData(
+                        $associatedTaxableData,
+                        $quote->getStoreId()
+                    );
+                    $associatedTaxable = $this->associatedTaxableFactory->create(
+                        [
+                            'data' => $associatedTaxableData
+                        ]
+                    );
+                    $associatedTaxable->setInvoiceId(null);
+                    $associatedTaxable->setOrderItemId(null);
+                    $associatedTaxable->setOrderId($order->getId());
+                    try {
+                        $this->associatedTaxableRepository->save($associatedTaxable);
+                    } catch (\Exception $e) {
+                        $this->avataxLogger->error(
+                            "There was a problem saving associated taxable quote information for order {$order->getId()}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Plugin/Sales/Model/Spi/CreditmemoResource.php
+++ b/Plugin/Sales/Model/Spi/CreditmemoResource.php
@@ -142,9 +142,9 @@ class CreditmemoResource
                 if (!empty($itemTaxesMap)) {
                     /** @var \Magento\Sales\Model\Order\Invoice\Item $item */
                     foreach ($entity->getAllItems() as $item) {
-                        if (isset($itemTaxesMap[$item->getOrderItem()->getQuoteItemId()])) {
+                        if (isset($itemTaxesMap[$item->getOrderItem()->getId()])) {
                             /** @var AssociatedTaxableInterface[] $taxable */
-                            $taxables = $itemTaxesMap[$item->getOrderItem()->getQuoteItemId()];
+                            $taxables = $itemTaxesMap[$item->getOrderItem()->getId()];
                             /** @var AssociatedTaxableInterface $taxable */
                             foreach ($taxables as $taxable) {
                                 if ($taxable->getCreditMemoId() === null) {

--- a/Plugin/Sales/Model/Spi/InvoiceResource.php
+++ b/Plugin/Sales/Model/Spi/InvoiceResource.php
@@ -142,9 +142,9 @@ class InvoiceResource
                 if (!empty($itemTaxesMap)) {
                     /** @var \Magento\Sales\Model\Order\Invoice\Item $item */
                     foreach ($entity->getAllItems() as $item) {
-                        if (isset($itemTaxesMap[$item->getOrderItem()->getQuoteItemId()])) {
+                        if (isset($itemTaxesMap[$item->getOrderItem()->getId()])) {
                             /** @var AssociatedTaxableInterface[] $taxable */
-                            $taxables = $itemTaxesMap[$item->getOrderItem()->getQuoteItemId()];
+                            $taxables = $itemTaxesMap[$item->getOrderItem()->getId()];
                             /** @var AssociatedTaxableInterface $taxable */
                             foreach ($taxables as $taxable) {
                                 if ($taxable->getInvoiceId() === null) {

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -223,6 +223,177 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ->setComment('AvaTax Sales Credit Memo Table');
             $setup->getConnection(self::$connectionName)->createTable($table);
         }
+
+        if (version_compare($context->getVersion(), '1.0.1', '<')) {
+            $table = $setup->getConnection(self::$connectionName)
+                ->newTable(
+                    $setup->getTable('avatax_associated_taxables')
+                )
+                ->addColumn(
+                    'id',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                    null,
+                    [
+                        'nullable' => false,
+                        'identity' => true,
+                        'primary' => true
+                    ],
+                    'ID'
+                )
+                ->addColumn(
+                    'order_item_id',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                    10,
+                    [
+                        'nullable' => true,
+                        'unsigned' => true,
+                    ],
+                    'Quote Item ID'
+                )
+                ->addColumn(
+                    'credit_memo_id',
+                    Table::TYPE_INTEGER,
+                    10,
+                    [
+                        'nullable' => true,
+                        'unsigned' => true
+                    ],
+                    'Credit Memo ID'
+                )
+                ->addColumn(
+                    'order_id',
+                    Table::TYPE_INTEGER,
+                    10,
+                    [
+                        'nullable' => true,
+                        'unsigned' => true
+                    ],
+                    'Order ID'
+                )
+                ->addColumn(
+                    'invoice_id',
+                    Table::TYPE_INTEGER,
+                    10,
+                    [
+                        'nullable' => true,
+                        'unsigned' => true
+                    ],
+                    'Invoice ID'
+                )
+                ->addColumn(
+                    'type',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    null,
+                    [
+                        'nullable' => true,
+                    ],
+                    'Associated taxable type'
+                )
+                ->addColumn(
+                    'code',
+                    Table::TYPE_TEXT,
+                    null,
+                    [
+                        'nullable' => true
+                    ],
+                    'Associated taxable code'
+                )
+                ->addColumn(
+                    'unit_price',
+                    Table::TYPE_FLOAT,
+                    null,
+                    [
+                        'nullable' => true
+                    ],
+                    'Associated taxable unit price'
+                )
+                ->addColumn(
+                    'base_unit_price',
+                    Table::TYPE_FLOAT,
+                    null,
+                    [
+                        'nullable' => true
+                    ],
+                    'Associated taxable base unit price'
+                )
+                ->addColumn(
+                    'quantity',
+                    Table::TYPE_FLOAT,
+                    null,
+                    [
+                        'nullable' => true
+                    ],
+                    'Associated taxable quantity'
+                )
+                ->addColumn(
+                    'tax_class_id',
+                    Table::TYPE_FLOAT,
+                    null,
+                    [
+                        'nullable' => true
+                    ],
+                    'Associated taxable tax class ID'
+                )
+                ->addColumn(
+                    'price_includes_tax',
+                    Table::TYPE_FLOAT,
+                    null,
+                    [
+                        'nullable' => true
+                    ],
+                    'Associated taxable price includes tax flag'
+                )
+                ->addColumn(
+                    'associated_item_code',
+                    Table::TYPE_TEXT,
+                    null,
+                    [
+                        'nullable' => true
+                    ],
+                    'Associated taxable associated item code'
+                )
+                ->addForeignKey(
+                    $setup->getFkName(
+                        'avatax_associated_taxables',
+                        'order_item_id',
+                        'sales_order_item',
+                        'item_id'
+                    ),
+                    'order_item_id',
+                    $setup->getTable('sales_order_item'),
+                    'item_id',
+                    Table::ACTION_CASCADE
+                )
+                ->setComment('Order item associated with taxable')
+                ->addForeignKey(
+                    $setup->getFkName(
+                        'avatax_associated_taxables',
+                        'invoice_id',
+                        'sales_invoice',
+                        'entity_id'
+                    ),
+                    'invoice_id',
+                    $setup->getTable('sales_invoice'),
+                    'entity_id',
+                    Table::ACTION_CASCADE
+                )
+                ->setComment('Invoice associated with the item')
+                ->addForeignKey(
+                    $setup->getFkName(
+                        'avatax_associated_taxables',
+                        'order_id',
+                        'sales_order',
+                        'entity_id'
+                    ),
+                    'order_id',
+                    $setup->getTable('sales_order'),
+                    'entity_id',
+                    Table::ACTION_CASCADE
+                )
+                ->setComment('Credit Memo associated with the item');
+
+            $setup->getConnection(self::$connectionName)->createTable($table);
+        }
         $setup->endSetup();
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -75,7 +75,7 @@
             </argument>
         </arguments>
     </virtualType>
-    <virtualType name="ClassyLlama\AvaTax\Model\Api\SearchCriteria\CollectionProcessor\AssociatedTaxableFilterProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor">
+    <virtualType name="ClassyLlama\AvaTax\Model\Api\SearchCriteria\CollectionProcessor\AssociatedTaxableFilterProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor\FilterProcessor">
         <arguments>
             <argument name="fieldMapping" xsi:type="array">
                 <item name="order_id" xsi:type="string">main_table.order_id</item>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -48,6 +48,33 @@
     <preference for="Magento\Tax\Api\Data\GrandTotalRatesInterface" type="ClassyLlama\AvaTax\Model\Tax\Calculation\GrandTotalRates" />
     <preference for="ClassyLlama\AvaTax\Api\Data\GrandTotalRatesInterface" type="ClassyLlama\AvaTax\Model\Tax\Calculation\GrandTotalRates" />
 
+    <preference for="ClassyLlama\AvaTax\Api\Data\AssociatedTaxableInterface" type="ClassyLlama\AvaTax\Model\Tax\AssociatedTaxable"/>
+    <preference for="ClassyLlama\AvaTax\Api\Data\AssociatedTaxableSearchResultsInterface" type="Magento\Framework\Api\SearchResults"/>
+
+    <preference for="ClassyLlama\AvaTax\Api\AssociatedTaxableRepositoryInterface" type="ClassyLlama\AvaTax\Model\Tax\AssociatedTaxableRepository"/>
+    <type name="ClassyLlama\AvaTax\Model\Tax\AssociatedTaxableRepository">
+        <arguments>
+            <argument name="collectionProcessor" xsi:type="object">ClassyLlama\AvaTax\Model\Api\SearchCriteria\AssociatedTaxableCollectionProcessor</argument>
+        </arguments>
+    </type>
+    <virtualType name="ClassyLlama\AvaTax\Model\Api\SearchCriteria\AssociatedTaxableCollectionProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor">
+        <arguments>
+            <argument name="processors" xsi:type="array">
+                <item name="joins" xsi:type="object">ClassyLlama\AvaTax\Model\Api\SearchCriteria\CollectionProcessor\AssociatedTaxableJoinProcessor</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="ClassyLlama\AvaTax\Model\Api\SearchCriteria\CollectionProcessor\AssociatedTaxableJoinProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor">
+        <arguments>
+            <argument name="customJoins" xsi:type="array">
+                <item name="order_id" xsi:type="object">ClassyLlama\AvaTax\Api\SearchCriteria\JoinProcessor\Order</item>
+            </argument>
+            <argument name="fieldMapping" xsi:type="array">
+                <item name="soi.order_id" xsi:type="string">order_id</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
     <preference for="Magento\Tax\Model\Sales\Total\Quote\Tax" type="ClassyLlama\AvaTax\Model\Tax\Sales\Total\Quote\Tax"/>
     <preference for="ClassyLlama\AvaTax\Api\Data\GetTaxResponseInterface" type="ClassyLlama\AvaTax\Framework\Interaction\Tax\Get\Response" />
     <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -60,6 +60,7 @@
     <virtualType name="ClassyLlama\AvaTax\Model\Api\SearchCriteria\AssociatedTaxableCollectionProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor">
         <arguments>
             <argument name="processors" xsi:type="array">
+                <item name="filters" xsi:type="object">ClassyLlama\AvaTax\Model\Api\SearchCriteria\CollectionProcessor\AssociatedTaxableFilterProcessor</item>
                 <item name="joins" xsi:type="object">ClassyLlama\AvaTax\Model\Api\SearchCriteria\CollectionProcessor\AssociatedTaxableJoinProcessor</item>
             </argument>
         </arguments>
@@ -71,6 +72,13 @@
             </argument>
             <argument name="fieldMapping" xsi:type="array">
                 <item name="soi.order_id" xsi:type="string">order_id</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="ClassyLlama\AvaTax\Model\Api\SearchCriteria\CollectionProcessor\AssociatedTaxableFilterProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor">
+        <arguments>
+            <argument name="fieldMapping" xsi:type="array">
+                <item name="order_id" xsi:type="string">main_table.order_id</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -21,4 +21,7 @@
     <event name="controller_action_predispatch_checkout_index_index">
         <observer name="avatax_checkout_index_index" instance="ClassyLlama\AvaTax\Observer\CalculateVirtualOrder" />
     </event>
+    <event name="sales_model_service_quote_submit_success">
+        <observer name="avatax_checkout_quote_submit_success" instance="ClassyLlama\AvaTax\Observer\QuoteSubmitSuccessObserver"/>
+    </event>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <!-- The setup_version attribute is unrelated to the module version stored in composer.json -->
-    <module name="ClassyLlama_AvaTax" setup_version="1.0.0">
+    <module name="ClassyLlama_AvaTax" setup_version="1.0.1">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Customer"/>


### PR DESCRIPTION
## Summary
Associated Taxables are used by Gift Wrapping, WEEE Tax, and some 3rd
party extension to allow calculcating tax for orders on items that are
not technically "items" in the Magento sense. This commit begins the
basic functionality of persisting the Associated Taxable information
from the order step so it can be re-transmitted to Avalara at the time
of invoice processing.

## Description
1. The Associated Taxable persistence begins at in the [QuoteSubmitSuccessObserver](https://github.com/classyllama/ClassyLlama_AvaTax/pull/213/files#diff-4f27843eecde589e445672d4a8e3880d)
   1. Each item in the quote is iterated over and the associated taxables saved each in their own row within the `avatax_associated_taxables` table. An example of an Associated Taxable at the item level is gift wrapping.
   2. The quote is checked for Associated Taxables, if they exist then they are also saved to the `avatax_associated_taxables` table with the `associated_item_code` of 'quote' and a `NULL` `order_item_id` to distinguish them from item-level taxables. An example of a quote-level associated taxable is a printed gift card
2. We don't care about these Associated Taxables again until an invoice is created for the order, I've added code to the existing [Invoice `aroundSave` plugin](https://github.com/classyllama/ClassyLlama_AvaTax/pull/213/files#diff-6ba84efa2fc8cd533ca284b7bb1277fdR134) that gets the associated taxables tied to each item invoiced and all the quote level items if they've not yet been invoiced and fills their `invoice_id` column with the invoice's id to indicate they are now associated with that invoice and should be used when the AvaTax queue is processed.
3. I added code to the [getTaxRequestForSalesObject](https://github.com/classyllama/ClassyLlama_AvaTax/pull/213/files#diff-defa2a9dc80d5ddb4732d944799e9648R668) (which is used to build the request that will be sent to Avalara for a given invoice or credit memo when the queue is processed) that pulls in all Associated Taxables associated with that invoice or creditmemo and [builds them into lines](https://github.com/classyllama/ClassyLlama_AvaTax/pull/213/files#diff-791fb5aa1dfb929abcdbd42be1c6992eR248) that will be sent to Avalara.

#### Associated Taxables Example Data
<img width="1326" alt="avatax_associated_taxables 2019-01-29 10-08-10" src="https://user-images.githubusercontent.com/6181127/51922001-ec29fd80-23ad-11e9-844c-05316ddbb263.png">


## Things that need to be tested

- [ ] Different currency
- [ ] Multiple address checkout
