### PR TITLE
AVS-421_109 - Change default.js to mixin

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -15,7 +15,6 @@
 var config = {
     map: {
         '*': {
-            "Magento_Checkout/js/model/shipping-save-processor/default": 'ClassyLlama_AvaTax/js/model/shipping-save-processor/default',
             "Magento_Checkout/js/model/shipping-save-processor/gift-registry": 'ClassyLlama_AvaTax/js/model/shipping-save-processor/gift-registry',
             "Magento_Tax/template/checkout/cart/totals/tax": 'ClassyLlama_AvaTax/template/checkout/cart/totals/tax',
             "Magento_Checkout/template/payment-methods/list": 'ClassyLlama_AvaTax/template/payment-methods/list',
@@ -27,6 +26,9 @@ var config = {
     },
     config: {
         mixins: {
+            'Magento_Checkout/js/model/shipping-save-processor/default': {
+                'ClassyLlama_AvaTax/js/model/shipping-save-processor/default': true
+            },
             'Magento_Checkout/js/view/payment/list': {
                 'ClassyLlama_AvaTax/js/view/payment/list/certificates-link': true
             },

--- a/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -40,9 +40,9 @@ define(
     ) {
         'use strict';
 
-        return {
-            validateAddressContainerSelector: '#validate_address',
-            saveShippingInformation: function () {
+        return function (module) {
+            var validateAddressContainerSelector = '#validate_address';
+            module.saveShippingInformation = function () {
                 var payload;
 
                 if (!quote.billingAddress()) {
@@ -71,7 +71,7 @@ define(
                         try {
                             checkoutValidationHandler.validationResponseHandler(response);
                         } catch (e) {
-                            $(this.validateAddressContainerSelector + " *").hide();
+                            $(validateAddressContainerSelector + " *").hide();
                         }
                         // End Edit
                         fullScreenLoader.stopLoader();
@@ -89,7 +89,8 @@ define(
                         fullScreenLoader.stopLoader();
                     }
                 );
-            }
+            };
+            return module;
         };
     }
 );


### PR DESCRIPTION
Allows payloadExtender to be modified in versions of Magento that allow it without breaking backwards compatibility (see #214)