### PR TITLE
AVS-421_109 - Use payloadExtender if possible (2.2+). otherwise ignore

### DIFF
--- a/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -25,20 +25,31 @@ define(
         'ClassyLlama_AvaTax/js/view/checkout-validation-handler',
         'Magento_Ui/js/modal/alert'
     ],
-    function (
-        $,
-        quote,
-        resourceUrlManager,
-        storage,
-        paymentService,
-        methodConverter,
-        errorProcessor,
-        fullScreenLoader,
-        selectBillingAddressAction,
-        checkoutValidationHandler,
-        alert
-    ) {
+    function ($,
+              quote,
+              resourceUrlManager,
+              storage,
+              paymentService,
+              methodConverter,
+              errorProcessor,
+              fullScreenLoader,
+              selectBillingAddressAction,
+              checkoutValidationHandler,
+              alert) {
         'use strict';
+
+        var getPayloadExtender = function() {
+            var extenderRequest = new $.Deferred();
+            require(
+                ['Magento_Checkout/js/model/shipping-save-processor/payload-extender'],
+                function (payloadExtender) {
+                    extenderRequest.resolve(payloadExtender);
+                }, function (err) {
+                    extenderRequest.reject(err);
+                }
+            );
+            return extenderRequest.promise();
+        };
 
         return function (module) {
             var validateAddressContainerSelector = '#validate_address';
@@ -58,37 +69,45 @@ define(
                     }
                 };
 
-                fullScreenLoader.startLoader();
+                return $.when(getPayloadExtender()).then(function (extender) {
+                    extender(payload);
+                    return payload;
+                }, function (err) {
+                    // payloadExtender doesn't exist in 2.1, no problem
+                    return $.when(payload);
+                }).done(function (pl) {
+                    fullScreenLoader.startLoader();
 
-                return storage.post(
-                    resourceUrlManager.getUrlForSetShippingInformation(quote),
-                    JSON.stringify(payload)
-                ).done(
-                    function (response) {
-                        quote.setTotals(response.totals);
-                        paymentService.setPaymentMethods(methodConverter(response.payment_methods));
-                        // Begin Edit
-                        try {
-                            checkoutValidationHandler.validationResponseHandler(response);
-                        } catch (e) {
-                            $(validateAddressContainerSelector + " *").hide();
+                    return storage.post(
+                        resourceUrlManager.getUrlForSetShippingInformation(quote),
+                        JSON.stringify(pl)
+                    ).done(
+                        function (response) {
+                            quote.setTotals(response.totals);
+                            paymentService.setPaymentMethods(methodConverter(response.payment_methods));
+                            // Begin Edit
+                            try {
+                                checkoutValidationHandler.validationResponseHandler(response);
+                            } catch (e) {
+                                $(validateAddressContainerSelector + " *").hide();
+                            }
+                            // End Edit
+                            fullScreenLoader.stopLoader();
                         }
-                        // End Edit
-                        fullScreenLoader.stopLoader();
-                    }
-                ).fail(
-                    function (response) {
-                        // Begin Edit - Native error message display is not obvious enough, so add to an alert box
-                        var messageObject = JSON.parse(response.responseText);
-                        alert({
-                            title: $.mage.__('Error'),
-                            content: messageObject.message
-                        });
-                        //errorProcessor.process(response);
-                        // End Edit
-                        fullScreenLoader.stopLoader();
-                    }
-                );
+                    ).fail(
+                        function (response) {
+                            // Begin Edit - Native error message display is not obvious enough, so add to an alert box
+                            var messageObject = JSON.parse(response.responseText);
+                            alert({
+                                title: $.mage.__('Error'),
+                                content: messageObject.message
+                            });
+                            //errorProcessor.process(response);
+                            // End Edit
+                            fullScreenLoader.stopLoader();
+                        }
+                    );
+                });
             };
             return module;
         };


### PR DESCRIPTION
This PR addresses an issue in Magento 2.2 where the payloadExtender cannot be used while also allowing the code to function correctly on 2.1 where the payloadExtender does not exist

Note that in 2.1 there will be a 404 error reported when we try to determine if the payloadExtender exists