### PR TITLE
Feature/avs 421 129 allow tax calc before discount

### DIFF
--- a/Framework/Interaction/Line.php
+++ b/Framework/Interaction/Line.php
@@ -260,9 +260,12 @@ class Line
         $description = $extensionAttributes ? $extensionAttributes->getAvataxDescription() : '';
         $taxCode = $extensionAttributes ? $extensionAttributes->getAvataxTaxCode() : null;
 
-        // The AvaTax 15 API doesn't support the concept of line-based discounts, so subtract discount amount
-        // from taxable amount
-        $amount = ($item->getUnitPrice() * $quantity) - $item->getDiscountAmount();
+        // Calculate tax with or without discount based on config setting
+        if ($this->config->getCalculateTaxBeforeDiscount($item->getStoreId())) {
+            $amount = $item->getUnitPrice() * $quantity;
+        } else {
+            $amount = ($item->getUnitPrice() * $quantity) - $item->getDiscountAmount();
+        }
 
         $ref1 = $extensionAttributes ? $extensionAttributes->getAvataxRef1() : null;
         $ref2 = $extensionAttributes ? $extensionAttributes->getAvataxRef2() : null;

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -47,6 +47,8 @@ class Config extends AbstractHelper
 
     const XML_PATH_AVATAX_REGION_FILTER_LIST = 'tax/avatax/region_filter_list';
 
+    const XML_PATH_AVATAX_CALCULATE_BEFORE_DISCOUNT = 'tax/avatax/calculate_tax_before_discounts';
+
     const XML_PATH_AVATAX_LIVE_MODE = 'tax/avatax/live_mode';
 
     const XML_PATH_AVATAX_PRODUCTION_ACCOUNT_NUMBER = 'tax/avatax/production_account_number';
@@ -1071,5 +1073,18 @@ class Config extends AbstractHelper
             $isSellerImporterOfRecord = false;
         }
         return $isSellerImporterOfRecord;
+    }
+
+    /**
+     * @param $store
+     * @return mixed
+     */
+    public function getCalculateTaxBeforeDiscount($store)
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_AVATAX_CALCULATE_BEFORE_DISCOUNT,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -79,6 +79,15 @@
                         <field id="filter_tax_by_region">1</field>
                     </depends>
                 </field>
+                <field id="calculate_tax_before_discounts" translate="label" type="select" sortOrder="1008" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Calculate Tax Before Discount</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[Should tax be calculated on each item before discounts are applied ]]></comment>
+                    <depends>
+                        <field id="enabled">1</field>
+                        <field id="tax_mode" negative="1">1</field>
+                    </depends>
+                </field>
                 <field id="is_seller_importer_of_record" translate="label comment" type="select" sortOrder="1008" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Set Seller as Importer of Record for Global Transactions</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -56,6 +56,7 @@
                 <queue_admin_notification_enabled>1</queue_admin_notification_enabled>
                 <queue_failure_notification_enabled>1</queue_failure_notification_enabled>
                 <customer_code_format>id</customer_code_format>
+                <calculate_tax_before_discounts>0</calculate_tax_before_discounts>
             </avatax>
         </tax>
     </default>


### PR DESCRIPTION
This adds a configurable option to allow for taxes to be calculated before or after discounts are applied to the price of an item.